### PR TITLE
Add SWI-Prolog baseline testing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Install SWI-Prolog
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y swi-prolog-nox
+
       - name: Install dependencies
         run: |
           uv sync --all-extras
@@ -45,6 +50,7 @@ jobs:
         run: |
           uv run python -V
           uv pip list
+          swipl --version
 
       - name: Run tests
         env:

--- a/prolog/tests/conftest.py
+++ b/prolog/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Pytest configuration and fixtures for PyLog tests."""
+
+import pytest
+from prolog.tests.swi_baseline import swi_count, swi_onevar, is_swipl_available
+
+
+# Check if SWI-Prolog is available
+SWIPL_AVAILABLE = is_swipl_available()
+
+
+@pytest.fixture
+def swi():
+    """Fixture providing SWI-Prolog baseline testing utilities.
+    
+    Usage:
+        def test_something(swi):
+            count = swi.count("p(1). p(2).", "p(X)")
+            assert count == 2
+            
+            values = swi.onevar("", "member(X, [a,b,c])", "X")
+            assert values == ["a", "b", "c"]
+    """
+    if not SWIPL_AVAILABLE:
+        pytest.skip("SWI-Prolog not available")
+    
+    class SWIHarness:
+        """Wrapper class for SWI baseline functions."""
+        count = staticmethod(swi_count)
+        onevar = staticmethod(swi_onevar)
+    
+    return SWIHarness
+
+
+# Marker for tests that require SWI-Prolog
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers", 
+        "swi_baseline: mark test as requiring SWI-Prolog for baseline comparison"
+    )
+
+
+# Auto-skip SWI baseline tests if SWI-Prolog is not available
+def pytest_collection_modifyitems(config, items):
+    """Modify test collection to skip SWI tests when appropriate."""
+    if SWIPL_AVAILABLE:
+        return
+    
+    skip_swi = pytest.mark.skip(reason="SWI-Prolog not available")
+    for item in items:
+        if "swi_baseline" in item.keywords:
+            item.add_marker(skip_swi)

--- a/prolog/tests/swi_baseline.py
+++ b/prolog/tests/swi_baseline.py
@@ -1,0 +1,168 @@
+"""SWI-Prolog baseline testing harness.
+
+This module provides utilities to run Prolog programs in SWI-Prolog
+and extract results for comparison with PyLog behavior.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Optional
+
+
+# Allow override via environment variable
+SWIPL = os.environ.get("SWIPL", "swipl")
+
+
+def _run_swipl(pl_source: str, goal: str, mode: str, var: Optional[str] = None) -> str:
+    """Run a Prolog program in SWI-Prolog and extract results.
+    
+    Args:
+        pl_source: The Prolog program source code
+        goal: The goal to execute
+        mode: Either "count" (count solutions) or "onevar" (extract single variable)
+        var: Variable name for onevar mode
+        
+    Returns:
+        Raw output from SWI-Prolog
+        
+    Raises:
+        RuntimeError: If SWI-Prolog execution fails
+    """
+    # Write temp .pl file combining program and driver
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "prog.pl"
+        
+        # Prepare the program
+        prog = textwrap.dedent(pl_source).strip() + "\n" if pl_source else ""
+        
+        if mode == "count":
+            # Count solutions using aggregate_all
+            main = f"""
+            :- use_module(library(aggregate)).
+            :- initialization(run, main).
+            
+            run :-
+                Goal = ({goal}),
+                (   aggregate_all(count, Goal, N)
+                ->  format("~d", [N])
+                ;   format("0", [])
+                ),
+                halt.
+            """
+        elif mode == "onevar":
+            if not var:
+                raise ValueError("var is required for mode=onevar")
+            # Collect all bindings for a single variable
+            # Use numbervars to stabilize anonymous variables
+            main = f"""
+            :- initialization(run, main).
+            
+            run :-
+                Goal = ({goal}),
+                findall({var}, Goal, L0),
+                maplist(numbervars_stable, L0, L1),
+                maplist(term_string, L1, SL),
+                write_canonical_list(SL),
+                halt.
+            
+            % Helper to apply numbervars
+            numbervars_stable(Term, Term) :-
+                numbervars(Term, 0, _).
+            
+            % Write list in JSON-compatible format
+            write_canonical_list([]) :- write('[]').
+            write_canonical_list(L) :-
+                write('['),
+                write_list_items(L),
+                write(']').
+            
+            write_list_items([H]) :-
+                write('"'), write(H), write('"').
+            write_list_items([H|T]) :-
+                write('"'), write(H), write('",'),
+                write_list_items(T).
+            """
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+        
+        # Write the combined program
+        p.write_text(prog + "\n" + main, encoding="utf-8")
+        
+        # Call SWI-Prolog quietly
+        try:
+            res = subprocess.run(
+                [SWIPL, "-q", "-t", "halt", "-s", str(p)],
+                capture_output=True,
+                text=True,
+                timeout=5  # 5 second timeout
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("SWI-Prolog execution timed out")
+        except FileNotFoundError:
+            raise RuntimeError(f"SWI-Prolog not found at: {SWIPL}")
+        
+        if res.returncode != 0:
+            error_msg = res.stderr.strip() or res.stdout.strip()
+            raise RuntimeError(f"SWI-Prolog failed: {error_msg}")
+        
+        return res.stdout.strip()
+
+
+def swi_count(program_pl: str, goal_pl: str) -> int:
+    """Count the number of solutions for a goal in SWI-Prolog.
+    
+    Args:
+        program_pl: Prolog program source (can be empty string)
+        goal_pl: Goal to execute
+        
+    Returns:
+        Number of solutions
+    """
+    out = _run_swipl(program_pl, goal_pl, "count")
+    return int(out or "0")
+
+
+def swi_onevar(program_pl: str, goal_pl: str, var: str) -> list[str]:
+    """Get all bindings for a single variable from SWI-Prolog.
+    
+    Args:
+        program_pl: Prolog program source (can be empty string)
+        goal_pl: Goal to execute
+        var: Variable name to extract (e.g., "X")
+        
+    Returns:
+        List of string representations of the variable bindings
+    """
+    out = _run_swipl(program_pl, goal_pl, "onevar", var=var)
+    
+    # Parse the JSON-like output
+    try:
+        # Handle empty list
+        if out == "[]":
+            return []
+        # Parse as JSON
+        return json.loads(out)
+    except json.JSONDecodeError:
+        # Fallback: return raw output for debugging
+        return [out] if out else []
+
+
+def is_swipl_available() -> bool:
+    """Check if SWI-Prolog is available on the system.
+    
+    Returns:
+        True if swipl can be executed, False otherwise
+    """
+    try:
+        result = subprocess.run(
+            [SWIPL, "--version"],
+            capture_output=True,
+            timeout=2
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False

--- a/prolog/tests/unit/test_swi_baseline.py
+++ b/prolog/tests/unit/test_swi_baseline.py
@@ -1,0 +1,88 @@
+"""Tests for SWI-Prolog baseline functionality."""
+
+import pytest
+from prolog.tests.swi_baseline import is_swipl_available
+
+
+pytestmark = pytest.mark.swi_baseline
+
+
+class TestSWIBaseline:
+    """Test that the SWI baseline harness works correctly."""
+    
+    def test_swi_available(self):
+        """Test that we can detect SWI-Prolog availability."""
+        # This will be True in CI and on dev machines with SWI installed
+        # The test will be skipped if SWI is not available
+        assert is_swipl_available()
+    
+    def test_count_simple(self, swi):
+        """Test counting solutions for simple predicates."""
+        prog = "p(1). p(2). p(3)."
+        assert swi.count(prog, "p(X)") == 3
+        assert swi.count(prog, "p(1)") == 1
+        assert swi.count(prog, "p(4)") == 0
+    
+    def test_count_conjunction(self, swi):
+        """Test counting solutions for conjunctions."""
+        prog = """
+        p(1). p(2).
+        q(a). q(b).
+        """
+        # All combinations
+        assert swi.count(prog, "p(X), q(Y)") == 4
+        # Specific binding
+        assert swi.count(prog, "p(1), q(Y)") == 2
+    
+    def test_count_disjunction(self, swi):
+        """Test counting solutions for disjunctions."""
+        prog = "p(1). q(2)."
+        assert swi.count(prog, "(p(X) ; q(X))") == 2
+    
+    def test_count_cut(self, swi):
+        """Test that cut affects solution count."""
+        prog = "p(1). p(2). p(3)."
+        # Without cut: all solutions
+        assert swi.count(prog, "p(X)") == 3
+        # With cut: only first
+        assert swi.count(prog, "p(X), !") == 1
+    
+    def test_onevar_atoms(self, swi):
+        """Test extracting atom values."""
+        prog = "color(red). color(green). color(blue)."
+        values = swi.onevar(prog, "color(X)", "X")
+        assert values == ["red", "green", "blue"]
+    
+    def test_onevar_numbers(self, swi):
+        """Test extracting number values."""
+        prog = "num(1). num(2). num(3)."
+        values = swi.onevar(prog, "num(X)", "X")
+        assert values == ["1", "2", "3"]
+    
+    def test_onevar_empty(self, swi):
+        """Test extracting from failed goals."""
+        prog = "p(1)."
+        values = swi.onevar(prog, "p(2)", "X")
+        assert values == []
+    
+    def test_onevar_builtin_member(self, swi):
+        """Test member/2 builtin."""
+        # No program needed for builtins
+        values = swi.onevar("", "member(X, [a, b, c])", "X")
+        assert values == ["a", "b", "c"]
+    
+    def test_catch_throw_baseline(self, swi):
+        """Test catch/throw behavior matches SWI."""
+        prog = ""
+        # Caught exception succeeds
+        assert swi.count(prog, "catch(throw(ball), ball, true)") == 1
+        # Caught with unification
+        assert swi.count(prog, "catch(throw(error(type, context)), error(X, Y), true)") == 1
+    
+    def test_once_baseline(self, swi):
+        """Test once/1 behavior."""
+        prog = "p(1). p(2). p(3)."
+        # once/1 commits to first solution
+        assert swi.count(prog, "once(p(X))") == 1
+        values = swi.onevar(prog, "once(p(X))", "X")
+        assert values == ["1"]

--- a/prolog/tests/unit/test_swi_baseline.py
+++ b/prolog/tests/unit/test_swi_baseline.py
@@ -79,6 +79,17 @@ class TestSWIBaseline:
         # Caught with unification
         assert swi.count(prog, "catch(throw(error(type, context)), error(X, Y), true)") == 1
     
+    def test_catch_recovery_fails_conjunction_baseline(self, swi):
+        """Test the controversial catch case - recovery failure in conjunction.
+        
+        This explicitly documents that when catch's recovery fails, the entire
+        conjunction fails, giving 0 solutions. This matches ISO/SWI semantics.
+        """
+        prog = "p(1). p(2)."
+        goal = "p(X), catch(throw(t), t, fail)"
+        # ISO/SWI: catch fails, conjunction fails → 0 solutions
+        assert swi.count(prog, goal) == 0
+    
     def test_once_baseline(self, swi):
         """Test once/1 behavior."""
         prog = "p(1). p(2). p(3)."

--- a/prolog/tests/unit/test_throw_catch.py
+++ b/prolog/tests/unit/test_throw_catch.py
@@ -183,6 +183,15 @@ class TestThrowCatch:
         results = list(engine.query("p(X), catch(throw(t), t, fail)"))
         assert len(results) == 0
     
+    @pytest.mark.swi_baseline
+    def test_catch_recovery_fails_transparent_baseline(self, swi):
+        """Validate transparent backtracking against SWI-Prolog."""
+        prog = "p(1). p(2)."
+        goal = "p(X), catch(throw(t), t, fail)"
+        
+        # SWI-Prolog should also give 0 solutions
+        assert swi.count(prog, goal) == 0
+    
     def test_nested_catch(self):
         """Test nested catch/3 calls."""
         engine = Engine(Program(()))
@@ -344,6 +353,19 @@ class TestThrowCatch:
         assert len(results) == 2
         assert results[0]["X"] == Int(1)
         assert results[1]["X"] == Int(2)
+    
+    @pytest.mark.swi_baseline
+    def test_transparent_backtracking_observable_baseline(self, swi):
+        """Validate transparency observation against SWI-Prolog."""
+        prog = "p(1). p(2)."
+        goal = "p(X), (catch(throw(t), t, fail) ; true)"
+        
+        # SWI should give 2 solutions (both p/1 alternatives succeed)
+        assert swi.count(prog, goal) == 2
+        
+        # Check the actual values
+        values = swi.onevar(prog, goal, "X")
+        assert values == ["1", "2"]
     
     def test_throw_cleans_unwinding(self):
         """Test that throw properly unwinds stacks."""


### PR DESCRIPTION
## Overview
This PR establishes a testing harness that compares PyLog behavior against SWI-Prolog for core Prolog features. This ensures our implementation matches standard Prolog semantics where appropriate.

Part of #30 (SWI-Prolog Baseline Epic)

## Changes
- Created `swi_baseline.py` harness for running SWI-Prolog tests
- Added pytest fixtures and markers for SWI baseline tests  
- Updated CI to install SWI-Prolog (`swi-prolog-nox` package)
- Added baseline tests for catch/3 transparent backtracking behavior
- Created comprehensive test suite demonstrating the baseline functionality

## Features
- **Solution counting**: Compare number of solutions between PyLog and SWI
- **Single-variable extraction**: Extract and compare variable bindings
- **Automatic skipping**: Tests skip gracefully if SWI-Prolog not available
- **CI integration**: SWI-Prolog installed in GitHub Actions for all test runs

## Usage
```python
@pytest.mark.swi_baseline
def test_something_baseline(swi):
    prog = "p(1). p(2)."
    goal = "p(X)"
    
    # Count solutions
    assert swi.count(prog, goal) == 2
    
    # Extract variable values
    values = swi.onevar(prog, goal, "X")
    assert values == ["1", "2"]
```

## Testing
- 13 SWI baseline tests passing locally
- Tests marked with `@pytest.mark.swi_baseline`
- Run with: `pytest -k swi_baseline`

## Next Steps
- Add baseline tests to existing control flow tests
- Expand to cover disjunction, cut, and if-then-else
- Document semantic differences where PyLog intentionally diverges