### PR TITLE
Fix test failure and pytest warning

### DIFF
--- a/prolog/tests/unit/test_repl.py
+++ b/prolog/tests/unit/test_repl.py
@@ -272,9 +272,9 @@ class TestREPLCommands:
         cmd = repl.parse_command("quit.")
         assert cmd["type"] == "quit"
         
-        # Test invalid command
+        # Test incomplete command (missing period)
         cmd = repl.parse_command("invalid input")
-        assert cmd["type"] == "error"
+        assert cmd["type"] == "incomplete"
     
     def test_parse_command_whitespace_and_missing_dot(self):
         """Test parsing commands with whitespace and missing dots."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,5 @@ markers = [
     "dev_mode: marks tests that should run in development mode",
     "iso_mode: marks tests that should run in ISO Prolog mode",
     "timeout: marks tests with a timeout limit",
+    "stage15: marks tests for Stage 1.5 (operator support)",
 ]


### PR DESCRIPTION
## Summary
- Fixed REPL test expectation: parse_command returns 'incomplete' for input without trailing period, not 'error'
- Registered stage15 pytest mark to eliminate unknown mark warning

## Test plan
- [x] Run full test suite with `uv run pytest`
- [x] Verify no test failures
- [x] Verify no pytest warnings

All 4657 tests pass with no warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)