### PR TITLE
Simplify Python version to 3.11+ only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout
@@ -38,8 +34,8 @@ jobs:
             **/pyproject.toml
             **/uv.lock
 
-      - name: Set up Python
-        run: uv python install ${{ matrix.python-version }}
+      - name: Set up Python 3.11
+        run: uv python install 3.11
 
       - name: Install SWI-Prolog
         run: |
@@ -70,7 +66,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-py${{ matrix.python-version }}
+          name: test-results
           path: pytest.xml
           if-no-files-found: ignore
 
@@ -78,22 +74,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-py${{ matrix.python-version }}
+          name: coverage-reports
           path: |
             coverage.xml
             .coverage
           if-no-files-found: ignore
 
-      - name: Upload coverage.xml artifact
-        if: matrix.python-version == '3.11'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-xml
-          path: coverage.xml
-          if-no-files-found: warn
-
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/xpqz/pylog/actions/workflows/ci.yml/badge.svg)](https://github.com/xpqz/pylog/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/xpqz/pylog/branch/main/graph/badge.svg)](https://codecov.io/gh/xpqz/pylog)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
 A tree-walking Prolog interpreter in Python with CLP(FD) (Constraint Logic Programming over Finite Domains).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pylog"
 version = "0.1.0"
 description = "A tree-walking Prolog interpreter in Python with CLP(FD)"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "lark>=1.1.0",
     "prompt-toolkit>=3.0.52",
@@ -32,7 +32,7 @@ packages = ["prolog"]
 
 [tool.black]
 line-length = 88
-target-version = ["py310", "py311", "py312"]
+target-version = ["py311", "py312"]
 
 [tool.pytest.ini_options]
 testpaths = ["prolog/tests"]


### PR DESCRIPTION
## Summary
- Simplify CI by removing matrix testing
- Standardize on Python 3.11 as minimum version
- Match local development environment

## Changes
- Remove Python version matrix from CI (was testing 3.10, 3.11, 3.12)
- Use only Python 3.11 in CI
- Update `requires-python` to `>=3.11` in pyproject.toml
- Update README badge to show Python 3.11+
- Simplify CI artifact names (no version suffixes)

## Rationale
- Reduces CI complexity and build time
- Matches local development environment (Python 3.11)
- Python 3.11 has significant performance improvements
- Simplifies maintenance and debugging

🤖 Generated with [Claude Code](https://claude.ai/code)