### PR TITLE
Comparison operators parsing - Issue #39

### DIFF
--- a/prolog/tests/unit/test_comparison_operators_parsing.py
+++ b/prolog/tests/unit/test_comparison_operators_parsing.py
@@ -465,6 +465,10 @@ class TestAdditionalCases:
         assert reader.read_term("X\\==Y") == Struct("\\==", (Var(0, "X"), Var(1, "Y")))
         assert reader.read_term("X@=<Y") == Struct("@=<", (Var(0, "X"), Var(1, "Y")))
         
+        # Additional tight tokenization tests for >= and @>=
+        assert reader.read_term("X>=Y") == Struct(">=", (Var(0, "X"), Var(1, "Y")))
+        assert reader.read_term("X@>=Y") == Struct("@>=", (Var(0, "X"), Var(1, "Y")))
+        
         # Tricky case: "=\\==" is actually invalid (can't have unary \\==)
         # This should raise an error
         with pytest.raises(ReaderError):


### PR DESCRIPTION
## Summary
Implements parsing and transformation of all comparison operators as part of Stage 1.5 (Epic #35).

## Changes
- Fixed tokenizer pattern ordering for proper multi-character operator recognition
- Added comprehensive tests for all comparison operators (50 tests)
- All operators correctly transform to canonical AST forms

## Operators Implemented
All at precedence 700, type xfx (non-chainable):

### Equality/Disequality
- `=` → `'='(X, Y)` - Unification
- `\=` → `'\\='(X, Y)` - Not unifiable

### Structural Comparison  
- `==` → `'=='(X, Y)` - Structural equality
- `\==` → `'\\=='(X, Y)` - Structural inequality

### Term Order
- `@<` → `'@<'(X, Y)` - Term less than
- `@>` → `'@>'(X, Y)` - Term greater than
- `@=<` → `'@=<'(X, Y)` - Term less or equal
- `@>=` → `'@>='(X, Y)` - Term greater or equal

### Arithmetic Comparison
- `<` → `'<'(X, Y)` - Less than
- `>` → `'>'(X, Y)` - Greater than  
- `=<` → `'=<'(X, Y)` - Less or equal
- `>=` → `'>='(X, Y)` - Greater or equal
- `=:=` → `'=:='(X, Y)` - Arithmetic equality
- `=\=` → `'=\\='(X, Y)` - Arithmetic inequality

## Key Features
✅ xfx non-chainable enforcement (e.g., `X = Y = Z` correctly rejected)
✅ Helpful error messages with position reporting
✅ Correct precedence interactions with arithmetic/control flow operators
✅ Robust tokenization of multi-character operators without spaces
✅ All operators already defined in operator table - only needed tokenizer fixes

## Test Results
- **New tests**: 50 comprehensive tests covering all operators and edge cases
- **Full suite**: 5008 tests passing
- **No regressions**

Closes #39