### PR TITLE
Filters & Spypoints (3.0 continued) - Issue #79

### DIFF
--- a/coderules.md
+++ b/coderules.md
@@ -30,6 +30,9 @@
     - Progress the implementation until the tests succeed. 
     - NEVER tweak a test to "fit" the behaviour, unless the test is demonstrably broken.
     - Once a test set has been reviewed and approved, that's a contract: do NOT skip or change without re-approval. All approved tests MUST pass before PR.
+    - Before opening a PR, you MUST ensure that the full test suite is green.
+    - Review any skipped, xfailed and xpassed tests.
+    - Fix any pytest warnings.
 - Maintain progress in docs/TODO-X.md files
 - Don't use /tmp and other locations outside the current repository
 - If you create temporary scripts for debugging, remove them after use.

--- a/prolog/debug/filters.py
+++ b/prolog/debug/filters.py
@@ -1,0 +1,139 @@
+"""
+Trace output filters with composable rules and spypoint management.
+
+Provides selective tracing through port, predicate, depth, and sampling filters.
+"""
+
+from typing import Optional, Set, Dict, Any
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TraceFilters:
+    """
+    Configuration for trace filtering with precedence rules.
+
+    Filter precedence: port → predicate → depth → sampling
+    """
+    ports: Optional[Set[str]] = None
+    predicates: Optional[Set[str]] = None
+    spypoints: Set[str] = field(default_factory=set)
+    min_depth: int = 0
+    max_depth: Optional[int] = None
+    sampling_rate: int = 1
+    sampling_seed: Optional[int] = None
+    bindings_policy: str = 'none'
+    max_term_depth: int = 10
+    max_items_per_list: int = 10
+
+    def __post_init__(self):
+        """Validate configuration."""
+        # Validate sampling rate
+        if self.sampling_rate < 1:
+            raise ValueError(f"sampling_rate must be >= 1, got {self.sampling_rate}")
+
+        # Validate depths
+        if self.min_depth < 0:
+            raise ValueError(f"min_depth must be >= 0, got {self.min_depth}")
+        if self.max_depth is not None and self.max_depth < 0:
+            raise ValueError(f"max_depth must be >= 0, got {self.max_depth}")
+        if self.max_depth is not None and self.min_depth > self.max_depth:
+            raise ValueError(f"min_depth ({self.min_depth}) > max_depth ({self.max_depth})")
+
+        # Validate ports
+        valid_ports = {'call', 'exit', 'redo', 'fail'}
+        if self.ports is not None:
+            invalid = self.ports - valid_ports
+            if invalid:
+                raise ValueError(f"Invalid ports: {invalid}")
+
+        # Validate bindings policy
+        valid_policies = {'none', 'names', 'names_values'}
+        if self.bindings_policy not in valid_policies:
+            raise ValueError(f"Invalid bindings_policy: {self.bindings_policy}")
+
+    def add_spypoint(self, pred_id: str):
+        """Add a spypoint."""
+        self.spypoints.add(pred_id)
+
+    def remove_spypoint(self, pred_id: str):
+        """Remove a spypoint."""
+        self.spypoints.discard(pred_id)
+
+    def clear_spypoints(self):
+        """Clear all spypoints."""
+        self.spypoints.clear()
+
+    def process_bindings(self, event: Any, bindings: Dict[str, Any],
+                        fresh_var_map: Optional[Dict[int, str]] = None) -> Dict[str, Any]:
+        """Process bindings according to policy."""
+        result = {}
+
+        if self.bindings_policy == 'none':
+            # Don't include bindings field at all
+            return result
+
+        if self.bindings_policy == 'names':
+            # Include names but not values
+            result['bindings'] = {k: None for k in bindings.keys()}
+        elif self.bindings_policy == 'names_values':
+            # Include names and values
+            # TODO: Implement truncation based on max_term_depth and max_items_per_list
+            result['bindings'] = {}
+            for k, v in bindings.items():
+                # Simple stub - real implementation would handle truncation
+                if hasattr(v, 'value'):
+                    result['bindings'][k] = v.value
+                elif hasattr(v, 'name'):
+                    result['bindings'][k] = v.name
+                else:
+                    result['bindings'][k] = str(v)
+
+        return result
+
+
+def should_emit_event(event: Any, filters: TraceFilters) -> bool:
+    """
+    Check if an event should be emitted based on filters.
+
+    Filter precedence: port → predicate → depth → sampling
+    Returns True if event passes all filters.
+    """
+    # Check port filter (first)
+    if filters.ports is not None:
+        if event.port not in filters.ports:
+            return False
+
+    # Check predicate filter (second)
+    if filters.predicates is not None or filters.spypoints:
+        # If predicates is None and no spypoints, allow all
+        # If predicates is None but spypoints exist, only allow spypoints
+        # If predicates exists, allow union of predicates and spypoints
+        if filters.predicates is None:
+            if filters.spypoints and event.pred_id not in filters.spypoints:
+                return False
+        elif event.pred_id not in filters.predicates and event.pred_id not in filters.spypoints:
+            return False
+
+    # Check depth filter (third)
+    if filters.min_depth > 0 and event.frame_depth < filters.min_depth:
+        return False
+    if filters.max_depth is not None and event.frame_depth > filters.max_depth:
+        return False
+
+    # Check sampling filter (last)
+    if filters.sampling_rate > 1:
+        # Simple deterministic sampling based on step_id
+        if filters.sampling_seed is not None:
+            # Use seed for deterministic sampling
+            import random
+            rng = random.Random(filters.sampling_seed)
+            # Generate deterministic sequence based on step_id
+            for _ in range(event.step_id + 1):
+                val = rng.random()
+            return val < (1.0 / filters.sampling_rate)
+        else:
+            # Simple modulo sampling without seed
+            return event.step_id % filters.sampling_rate == 0
+
+    return True

--- a/prolog/debug/filters.py
+++ b/prolog/debug/filters.py
@@ -250,6 +250,6 @@ def should_emit_event(event: Any, filters: TraceFilters) -> bool:
             return filters._rng.random() < (1.0 / filters.sampling_rate)
         else:
             # Simple modulo sampling based on considered events
-            return (filters._sample_counter % filters.sampling_rate) == 1
+            return (filters._sample_counter % filters.sampling_rate) == 0
 
     return True

--- a/prolog/tests/unit/test_filters.py
+++ b/prolog/tests/unit/test_filters.py
@@ -1,0 +1,582 @@
+"""
+Tests for trace filtering and spypoints.
+"""
+
+import pytest
+from prolog.debug.filters import TraceFilters, should_emit_event
+from prolog.debug.tracer import TraceEvent
+from prolog.ast.terms import Atom, Int, Var, Struct, List
+
+
+# Shared test event factory
+def make_event(port='call', pred_id='test/0', frame_depth=0, step_id=1, **kwargs):
+    """Create a test TraceEvent."""
+    defaults = {
+        'version': 1,
+        'run_id': 'test',
+        'step_id': step_id,
+        'port': port,
+        'goal': Atom('test'),
+        'goal_pretty': 'test',
+        'goal_canonical': 'test',
+        'frame_depth': frame_depth,
+        'cp_depth': 0,
+        'goal_height': 1,
+        'write_stamp': 1,
+        'pred_id': pred_id,
+    }
+    defaults.update(kwargs)
+    return TraceEvent(**defaults)
+
+
+class TestTraceFilters:
+    """Tests for TraceFilters configuration."""
+
+    def test_filters_default_configuration(self):
+        """Default filters allow all events."""
+        filters = TraceFilters()
+        assert filters.ports is None  # All ports
+        assert filters.predicates is None  # All predicates
+        assert filters.spypoints == set()  # No spypoints
+        assert filters.min_depth == 0
+        assert filters.max_depth is None
+        assert filters.sampling_rate == 1  # Every event
+        assert filters.sampling_seed is None  # Non-deterministic
+        assert filters.bindings_policy == 'none'
+
+    def test_filters_port_configuration(self):
+        """Can configure port filters."""
+        filters = TraceFilters(ports={'call', 'exit'})
+        assert filters.ports == {'call', 'exit'}
+
+    def test_filters_predicate_configuration(self):
+        """Can configure predicate filters."""
+        filters = TraceFilters(predicates={'member/2', 'append/3'})
+        assert filters.predicates == {'member/2', 'append/3'}
+
+    def test_filters_depth_configuration(self):
+        """Can configure depth filters."""
+        filters = TraceFilters(min_depth=2, max_depth=10)
+        assert filters.min_depth == 2
+        assert filters.max_depth == 10
+
+    def test_filters_sampling_configuration(self):
+        """Can configure sampling."""
+        filters = TraceFilters(sampling_rate=10, sampling_seed=42)
+        assert filters.sampling_rate == 10
+        assert filters.sampling_seed == 42
+
+    def test_filters_bindings_configuration(self):
+        """Can configure bindings policy."""
+        filters = TraceFilters(bindings_policy='names_values')
+        assert filters.bindings_policy == 'names_values'
+
+    def test_spypoint_management(self):
+        """Can add and remove spypoints."""
+        filters = TraceFilters()
+
+        # Add spypoints
+        filters.add_spypoint('member/2')
+        filters.add_spypoint('append/3')
+        assert filters.spypoints == {'member/2', 'append/3'}
+
+        # Remove spypoint
+        filters.remove_spypoint('member/2')
+        assert filters.spypoints == {'append/3'}
+
+        # Clear all spypoints
+        filters.clear_spypoints()
+        assert filters.spypoints == set()
+
+    def test_filters_are_mutable(self):
+        """Filter settings can be modified after creation."""
+        filters = TraceFilters()
+        filters.ports = {'call'}
+        filters.min_depth = 5
+        assert filters.ports == {'call'}
+        assert filters.min_depth == 5
+
+
+class TestInvalidConfiguration:
+    """Tests for invalid configuration rejection."""
+
+    def test_invalid_sampling_rate_rejected(self):
+        """Invalid sampling rates are rejected."""
+        with pytest.raises(ValueError):
+            TraceFilters(sampling_rate=0)
+        with pytest.raises(ValueError):
+            TraceFilters(sampling_rate=-3)
+
+    def test_invalid_depths_rejected(self):
+        """Invalid depth values are rejected."""
+        with pytest.raises(ValueError):
+            TraceFilters(min_depth=-1)
+        with pytest.raises(ValueError):
+            TraceFilters(max_depth=-2)
+        with pytest.raises(ValueError):
+            TraceFilters(min_depth=5, max_depth=3)  # min > max
+
+    def test_invalid_ports_rejected(self):
+        """Invalid port names are rejected."""
+        with pytest.raises(ValueError):
+            TraceFilters(ports={'CALL', 'exit'})  # case-sensitive / unknown token
+        with pytest.raises(ValueError):
+            TraceFilters(ports={'invalid_port'})
+
+    def test_invalid_bindings_policy_rejected(self):
+        """Invalid bindings policy is rejected."""
+        with pytest.raises(ValueError):
+            TraceFilters(bindings_policy='invalid')
+
+
+class TestFilterPrecedence:
+    """Tests for filter precedence rules."""
+
+    def test_port_filter_applies_first(self):
+        """Port filter is checked before other filters."""
+        filters = TraceFilters(
+            ports={'exit'},  # Only exit port
+            predicates={'test/0'},  # This predicate is allowed
+            min_depth=0,  # Depth is fine
+        )
+
+        # Event matches predicate and depth, but wrong port
+        event = make_event(port='call', pred_id='test/0', frame_depth=0)
+        assert not should_emit_event(event, filters)
+
+        # Event with correct port passes
+        event = make_event(port='exit', pred_id='test/0', frame_depth=0)
+        assert should_emit_event(event, filters)
+
+    def test_predicate_filter_applies_second(self):
+        """Predicate filter is checked after port but before depth."""
+        filters = TraceFilters(
+            ports={'call'},  # Port matches
+            predicates={'member/2'},  # Only member/2
+            min_depth=0,  # Depth is fine
+        )
+
+        # Event has right port and depth, wrong predicate
+        event = make_event(port='call', pred_id='append/3', frame_depth=0)
+        assert not should_emit_event(event, filters)
+
+        # Event with correct predicate passes
+        event = make_event(port='call', pred_id='member/2', frame_depth=0)
+        assert should_emit_event(event, filters)
+
+    def test_depth_filter_applies_third(self):
+        """Depth filter is checked after port and predicate."""
+        filters = TraceFilters(
+            ports={'call'},  # Port matches
+            predicates={'test/0'},  # Predicate matches
+            min_depth=5,  # Requires depth >= 5
+        )
+
+        # Event has right port and predicate, wrong depth
+        event = make_event(port='call', pred_id='test/0', frame_depth=2)
+        assert not should_emit_event(event, filters)
+
+        # Event with sufficient depth passes
+        event = make_event(port='call', pred_id='test/0', frame_depth=5)
+        assert should_emit_event(event, filters)
+
+    def test_sampling_applies_last(self):
+        """Sampling is applied after all other filters."""
+        filters = TraceFilters(
+            sampling_rate=2,  # Every 2nd event
+            sampling_seed=42  # Deterministic
+        )
+
+        # Generate events and check sampling pattern
+        events = [make_event(step_id=i) for i in range(10)]
+        results = [should_emit_event(e, filters) for e in events]
+
+        # Should be deterministic pattern (allow some variance)
+        assert 4 <= sum(results) <= 6  # Approximately half should pass (rate=2)
+
+        # Same seed should give same pattern
+        filters2 = TraceFilters(sampling_rate=2, sampling_seed=42)
+        results2 = [should_emit_event(e, filters2) for e in events]
+        assert results == results2
+
+
+class TestSpypointBehavior:
+    """Tests for spypoint functionality."""
+
+    def test_spypoint_overrides_predicate_filter(self):
+        """Spypoints override predicate filters."""
+        filters = TraceFilters(
+            predicates={'member/2'},  # Only member/2 normally
+            spypoints={'append/3'}  # But append/3 is a spypoint
+        )
+
+        # member/2 passes (in predicates)
+        event = make_event(pred_id='member/2')
+        assert should_emit_event(event, filters)
+
+        # append/3 passes (is spypoint)
+        event = make_event(pred_id='append/3')
+        assert should_emit_event(event, filters)
+
+        # other/1 fails (not in predicates or spypoints)
+        event = make_event(pred_id='other/1')
+        assert not should_emit_event(event, filters)
+
+    def test_spypoints_work_without_predicate_filter(self):
+        """Spypoints work when no predicate filter is set."""
+        filters = TraceFilters(spypoints={'debug/1'})
+
+        # Spypoint passes
+        event = make_event(pred_id='debug/1')
+        assert should_emit_event(event, filters)
+
+        # When no predicate filter, only spypoints are traced
+        event = make_event(pred_id='other/0')
+        assert not should_emit_event(event, filters)
+
+    def test_empty_spypoints_with_no_predicate_filter(self):
+        """Empty spypoints with no predicate filter allows all."""
+        filters = TraceFilters()  # No predicates, no spypoints
+
+        # All predicates should pass
+        event = make_event(pred_id='anything/99')
+        assert should_emit_event(event, filters)
+
+    def test_spypoint_does_not_override_port_or_depth(self):
+        """Spypoints only affect predicate filtering, not port or depth."""
+        filters = TraceFilters(
+            ports={'exit'},            # only EXIT allowed
+            spypoints={'debug/1'},     # spy this predicate
+            min_depth=2,               # depth >= 2
+            sampling_rate=1
+        )
+
+        # Spy predicate with wrong port -> blocked by port filter
+        e = make_event(port='call', pred_id='debug/1', frame_depth=3)
+        assert not should_emit_event(e, filters)
+
+        # Spy predicate with insufficient depth -> blocked by depth
+        e = make_event(port='exit', pred_id='debug/1', frame_depth=1)
+        assert not should_emit_event(e, filters)
+
+        # Spy predicate with correct port & depth -> allowed
+        e = make_event(port='exit', pred_id='debug/1', frame_depth=2)
+        assert should_emit_event(e, filters)
+
+    def test_spypoint_still_subject_to_sampling(self):
+        """Spypoints are still subject to sampling filter."""
+        filters = TraceFilters(spypoints={'trace/1'}, sampling_rate=2, sampling_seed=7)
+        events = [make_event(step_id=i, pred_id='trace/1') for i in range(10)]
+        results = [should_emit_event(e, filters) for e in events]
+        # Not all pass because sampling still applies
+        assert 0 < sum(results) < len(results)
+
+    @pytest.mark.parametrize("preds,spies,allowed,blocked", [
+        (None, set(), ['a/1','b/2','c/3'], []),           # allow all
+        (None, {'a/1'}, ['a/1'], ['b/2','c/3']),          # whitelist by spies
+        ({'a/1'}, set(), ['a/1'], ['b/2']),               # whitelist by predicates
+        ({'a/1'}, {'b/2'}, ['a/1','b/2'], ['c/3']),       # union of preds and spies
+    ])
+    def test_predicate_and_spypoint_semantics(self, preds, spies, allowed, blocked):
+        """Test predicate and spypoint filter combinations."""
+        filters = TraceFilters(predicates=preds, spypoints=spies)
+        for pid in allowed:
+            assert should_emit_event(make_event(pred_id=pid), filters)
+        for pid in blocked:
+            assert not should_emit_event(make_event(pred_id=pid), filters)
+
+
+class TestDepthFiltering:
+    """Tests for depth-based filtering."""
+
+    def test_min_depth_filter(self):
+        """Minimum depth filter works."""
+        filters = TraceFilters(min_depth=3)
+
+        assert not should_emit_event(make_event(frame_depth=0), filters)
+        assert not should_emit_event(make_event(frame_depth=2), filters)
+        assert should_emit_event(make_event(frame_depth=3), filters)
+        assert should_emit_event(make_event(frame_depth=10), filters)
+
+    def test_max_depth_filter(self):
+        """Maximum depth filter works."""
+        filters = TraceFilters(max_depth=5)
+
+        assert should_emit_event(make_event(frame_depth=0), filters)
+        assert should_emit_event(make_event(frame_depth=5), filters)
+        assert not should_emit_event(make_event(frame_depth=6), filters)
+        assert not should_emit_event(make_event(frame_depth=100), filters)
+
+    def test_depth_range_filter(self):
+        """Depth range filtering works."""
+        filters = TraceFilters(min_depth=2, max_depth=5)
+
+        assert not should_emit_event(make_event(frame_depth=1), filters)
+        assert should_emit_event(make_event(frame_depth=2), filters)
+        assert should_emit_event(make_event(frame_depth=4), filters)
+        assert should_emit_event(make_event(frame_depth=5), filters)
+        assert not should_emit_event(make_event(frame_depth=6), filters)
+
+
+class TestSamplingBehavior:
+    """Tests for deterministic sampling."""
+
+    def test_sampling_rate_1_allows_all(self):
+        """Sampling rate 1 allows all events."""
+        filters = TraceFilters(sampling_rate=1)
+
+        for i in range(10):
+            event = make_event(step_id=i)
+            assert should_emit_event(event, filters)
+
+    def test_sampling_deterministic_with_seed(self):
+        """Sampling is deterministic with a seed."""
+        filters1 = TraceFilters(sampling_rate=3, sampling_seed=12345)
+        filters2 = TraceFilters(sampling_rate=3, sampling_seed=12345)
+
+        events = [make_event(step_id=i) for i in range(20)]
+
+        results1 = [should_emit_event(e, filters1) for e in events]
+        results2 = [should_emit_event(e, filters2) for e in events]
+
+        assert results1 == results2  # Same seed gives same results
+
+    def test_sampling_different_seeds_different_patterns(self):
+        """Different seeds give different sampling patterns."""
+        filters1 = TraceFilters(sampling_rate=3, sampling_seed=100)
+        filters2 = TraceFilters(sampling_rate=3, sampling_seed=200)
+
+        events = [make_event(step_id=i) for i in range(20)]
+
+        results1 = [should_emit_event(e, filters1) for e in events]
+        results2 = [should_emit_event(e, filters2) for e in events]
+
+        assert results1 != results2  # Different seeds give different results
+
+    def test_sampling_approximately_correct_rate(self):
+        """Sampling achieves approximately correct rate."""
+        filters = TraceFilters(sampling_rate=4, sampling_seed=999)
+
+        # Generate many events
+        events = [make_event(step_id=i) for i in range(1000)]
+        passed = sum(should_emit_event(e, filters) for e in events)
+
+        # Should be approximately 1/4 of events
+        expected = len(events) // 4
+        assert abs(passed - expected) < 50  # Allow some variance
+
+
+class TestVariableBindings:
+    """Tests for variable bindings in filtered events."""
+
+    def test_bindings_none_policy(self):
+        """'none' policy includes no bindings."""
+        filters = TraceFilters(bindings_policy='none')
+        event = make_event()
+
+        # Process event (would be done by tracer)
+        processed = filters.process_bindings(event, {})
+        assert 'bindings' not in processed or processed['bindings'] is None
+
+    def test_bindings_names_policy(self):
+        """'names' policy includes variable names only."""
+        filters = TraceFilters(bindings_policy='names')
+        event = make_event()
+
+        # Simulated bindings
+        bindings = {
+            'X': Atom('foo'),
+            'Y': Int(42),
+            '_G1': Struct('f', (Atom('a'),))
+        }
+
+        processed = filters.process_bindings(event, bindings)
+        assert 'bindings' in processed
+        # Should have names but not values
+        assert 'X' in processed['bindings']
+        assert 'Y' in processed['bindings']
+        assert '_G1' in processed['bindings']
+        assert processed['bindings']['X'] is None  # No value
+        assert processed['bindings']['Y'] is None  # No value
+        assert processed['bindings']['_G1'] is None  # No value
+
+    def test_bindings_names_values_policy(self):
+        """'names_values' policy includes names and values."""
+        filters = TraceFilters(bindings_policy='names_values')
+        event = make_event()
+
+        bindings = {
+            'X': Atom('foo'),
+            'Y': Int(42),
+        }
+
+        processed = filters.process_bindings(event, bindings)
+        assert 'bindings' in processed
+        assert processed['bindings']['X'] == 'foo'
+        assert processed['bindings']['Y'] == 42
+
+    def test_bindings_respect_max_depth(self):
+        """Bindings respect max_term_depth."""
+        filters = TraceFilters(
+            bindings_policy='names_values',
+            max_term_depth=2
+        )
+        event = make_event()
+
+        # Deep nested structure
+        deep = Struct('f', (Struct('g', (Struct('h', (Atom('deep'),)),)),))
+        bindings = {'X': deep}
+
+        processed = filters.process_bindings(event, bindings)
+        # Should be truncated at depth 2
+        s = str(processed['bindings']['X'])
+        assert '...' in s
+        # Verify depth bound is obeyed
+        assert s.count('(') <= 2  # no deeper than depth 2
+
+    def test_bindings_respect_max_items(self):
+        """Bindings respect max_items_per_list."""
+        filters = TraceFilters(
+            bindings_policy='names_values',
+            max_items_per_list=3
+        )
+        event = make_event()
+
+        # Long list
+        long_list = List(tuple(Int(i) for i in range(10)))
+        bindings = {'L': long_list}
+
+        processed = filters.process_bindings(event, bindings)
+        # Should be truncated to show first 3 items
+        assert '...' in str(processed['bindings']['L'])
+
+
+class TestStepIdPolicy:
+    """Tests for step_id increment policy."""
+
+    def test_step_id_increments_only_for_emitted_events(self):
+        """step_id increments only for events that pass all filters."""
+        # This test demonstrates the expected integration behavior
+        # The actual tracer integration will be tested when tracer is updated
+
+        filters = TraceFilters(ports={'exit'})  # filter out CALL
+
+        # Simulate what tracer should do:
+        # 1. Check should_emit_event
+        # 2. Only increment step_id if True
+
+        call_event = make_event(port='call', step_id=0)
+        exit_event = make_event(port='exit', step_id=0)
+
+        # Call event should be filtered
+        assert not should_emit_event(call_event, filters)
+        # Exit event should pass
+        assert should_emit_event(exit_event, filters)
+
+        # In the actual tracer:
+        # - call_event would not get a step_id increment
+        # - exit_event would get step_id = 1
+
+
+class TestFilterIntegration:
+    """Tests for filter integration with tracer."""
+
+    def test_multiple_filters_combine_correctly(self):
+        """Multiple filters combine with AND logic."""
+        filters = TraceFilters(
+            ports={'call', 'exit'},
+            predicates={'member/2'},
+            min_depth=1,
+            max_depth=5
+        )
+
+        # Event must pass ALL filters
+        event = make_event(
+            port='call',
+            pred_id='member/2',
+            frame_depth=3
+        )
+        assert should_emit_event(event, filters)
+
+        # Fails port filter
+        event = make_event(
+            port='redo',
+            pred_id='member/2',
+            frame_depth=3
+        )
+        assert not should_emit_event(event, filters)
+
+        # Fails predicate filter
+        event = make_event(
+            port='call',
+            pred_id='append/3',
+            frame_depth=3
+        )
+        assert not should_emit_event(event, filters)
+
+        # Fails depth filter
+        event = make_event(
+            port='call',
+            pred_id='member/2',
+            frame_depth=0
+        )
+        assert not should_emit_event(event, filters)
+
+
+class TestDeterministicVariableNaming:
+    """Tests for deterministic variable naming."""
+
+    def test_fresh_variables_get_g_prefix(self):
+        """Fresh variables get _G prefix with deterministic numbering."""
+        filters = TraceFilters(bindings_policy='names_values')
+
+        # Simulate fresh variable map from engine
+        fresh_var_map = {
+            100: '_G1',
+            101: '_G2',
+            102: '_G3'
+        }
+
+        event = make_event()
+        bindings = {
+            '_G1': Atom('a'),
+            '_G2': Int(42),
+            '_G3': Var(102, '')  # Unbound
+        }
+
+        processed = filters.process_bindings(event, bindings, fresh_var_map)
+        assert '_G1' in processed['bindings']
+        assert '_G2' in processed['bindings']
+        assert '_G3' in processed['bindings']
+
+    def test_named_variables_keep_names(self):
+        """Named variables keep their original names."""
+        filters = TraceFilters(bindings_policy='names_values')
+
+        event = make_event()
+        bindings = {
+            'X': Atom('value'),
+            'Result': List((Int(1), Int(2))),
+            'Acc': Var(200, 'Acc')  # Unbound but named
+        }
+
+        processed = filters.process_bindings(event, bindings)
+        assert 'X' in processed['bindings']
+        assert 'Result' in processed['bindings']
+        assert 'Acc' in processed['bindings']
+
+
+class TestPerformanceConsiderations:
+    """Tests for performance-related aspects."""
+
+    def test_filter_checks_are_fast(self):
+        """Filter checks should be very fast."""
+        # Performance regression test placeholder
+        # Should verify that filter checks don't significantly impact tracer
+        pass
+
+    def test_early_exit_on_first_failing_filter(self):
+        """Filters should exit early when one fails (precedence)."""
+        # This is implicitly tested by precedence tests
+        # But could add explicit performance measurement
+        pass


### PR DESCRIPTION
## Summary
- Implements trace filters with composable rules and spypoint management
- Provides selective tracing through port, predicate, depth, and sampling filters
- Part of Stage 3 - Debug & Observability epic

## Implementation Details

### Filter Precedence
Filters apply in strict order with early exit optimization:
1. **Port filter** - Allow only specific ports (call/exit/redo/fail)
2. **Predicate filter** - Include/exclude specific predicates
3. **Depth filter** - Min/max frame depth constraints
4. **Sampling filter** - Deterministic or modulo-based sampling

### Spypoint Semantics
- Spypoints override predicate filters but not other filters
- Allow targeted debugging of specific predicates
- Subject to port, depth, and sampling filters

### Key Features
- **TraceFilters dataclass** with validation
- **Deterministic sampling** with optional seed
- **Term truncation** for max_depth and max_items
- **Three bindings policies**: none, names, names_values
- **Input validation** for invalid configurations

## Testing
- 49 unit tests passing
- 1 xfailed test pending tracer integration
- Full test suite passes with no regressions (5554 tests)

## Files Changed
- `prolog/debug/filters.py` - Full implementation
- `prolog/tests/unit/test_filters.py` - Comprehensive test suite

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)