### PR TITLE
Stage 5 Phase 6: Hook Integration and Property Tests (#126)

### DIFF
--- a/prolog/clpfd/props/neq.py
+++ b/prolog/clpfd/props/neq.py
@@ -1,0 +1,67 @@
+"""Not-equal propagator for CLP(FD).
+
+Implements X #\= Y propagation:
+- If one side is a singleton {v}, remove v from the other's domain.
+- If both sides are singletons with equal value, fail.
+"""
+
+from typing import Optional, List, Tuple
+from prolog.clpfd.api import get_domain, set_domain
+
+
+def create_not_equal_propagator(x_id: int, y_id: int):
+    """Create a not-equal propagator for X #\= Y.
+
+    Args:
+        x_id: Variable ID for X
+        y_id: Variable ID for Y
+
+    Returns:
+        Propagator function that enforces X #\= Y
+    """
+    def neq_propagator(store, trail, engine, cause) -> Tuple[str, Optional[List[int]]]:
+        """Propagate X #\= Y by removing singleton values from counterpart.
+
+        Returns:
+            ('ok', changed_vars) if propagation succeeded
+            ('fail', None) if inconsistency detected
+        """
+        x_dom = get_domain(store, x_id)
+        y_dom = get_domain(store, y_id)
+
+        # If no domains, nothing to propagate yet
+        if x_dom is None and y_dom is None:
+            return ('ok', None)
+
+        changed: List[int] = []
+
+        # If both have domains and both singletons
+        if x_dom is not None and y_dom is not None and x_dom.is_singleton() and y_dom.is_singleton():
+            if x_dom.min() == y_dom.min():  # same value
+                return ('fail', None)
+            return ('ok', None)
+
+        # If X is singleton, remove its value from Y's domain
+        if x_dom is not None and x_dom.is_singleton() and y_dom is not None:
+            val = x_dom.min()
+            new_y = y_dom.remove_value(val)
+            if new_y.is_empty():
+                return ('fail', None)
+            if new_y is not y_dom:
+                set_domain(store, y_id, new_y, trail)
+                changed.append(y_id)
+
+        # If Y is singleton, remove its value from X's domain
+        if y_dom is not None and y_dom.is_singleton() and x_dom is not None:
+            val = y_dom.min()
+            new_x = x_dom.remove_value(val)
+            if new_x.is_empty():
+                return ('fail', None)
+            if new_x is not x_dom:
+                set_domain(store, x_id, new_x, trail)
+                changed.append(x_id)
+
+        return ('ok', changed if changed else None)
+
+    return neq_propagator
+

--- a/prolog/clpfd/props/sum_const.py
+++ b/prolog/clpfd/props/sum_const.py
@@ -1,0 +1,65 @@
+"""Sum-with-constant propagator: Z = X + K."""
+
+from typing import Optional, List, Tuple
+from prolog.clpfd.api import get_domain, set_domain
+from prolog.clpfd.domain import Domain
+
+
+def _shift_domain(dom: Domain, delta: int) -> Domain:
+    """Shift a domain by an integer delta (add to all values)."""
+    if dom is None:
+        return None  # type: ignore
+    intervals = tuple((low + delta, high + delta) for (low, high) in dom.intervals)
+    return Domain(intervals)
+
+
+def create_sum_const_propagator(z_id: int, x_id: int, k: int):
+    """Create a propagator enforcing Z = X + K.
+
+    Args:
+        z_id: Var ID for Z
+        x_id: Var ID for X
+        k: constant integer
+    """
+    def prop(store, trail, engine, cause) -> Tuple[str, Optional[List[int]]]:
+        z_dom = get_domain(store, z_id)
+        x_dom = get_domain(store, x_id)
+
+        if z_dom is None and x_dom is None:
+            return ('ok', None)
+
+        changed: List[int] = []
+
+        # Narrow Z from X
+        if x_dom is not None:
+            z_from_x = _shift_domain(x_dom, k)
+            if z_dom is not None:
+                new_z = z_dom.intersect(z_from_x)
+            else:
+                new_z = z_from_x
+
+            if new_z.is_empty():
+                return ('fail', None)
+            if z_dom is None or new_z is not z_dom:
+                set_domain(store, z_id, new_z, trail)
+                changed.append(z_id)
+                z_dom = new_z
+
+        # Narrow X from Z
+        if z_dom is not None:
+            x_from_z = _shift_domain(z_dom, -k)
+            if x_dom is not None:
+                new_x = x_dom.intersect(x_from_z)
+            else:
+                new_x = x_from_z
+
+            if new_x.is_empty():
+                return ('fail', None)
+            if x_dom is None or new_x is not x_dom:
+                set_domain(store, x_id, new_x, trail)
+                changed.append(x_id)
+
+        return ('ok', changed if changed else None)
+
+    return prop
+

--- a/prolog/tests/scenarios/test_clpfd_scenarios.py
+++ b/prolog/tests/scenarios/test_clpfd_scenarios.py
@@ -1,0 +1,380 @@
+"""Integration tests for CLP(FD) scenarios - Phase 6 of Issue #126.
+
+Tests realistic constraint problems to verify the complete CLP(FD) system
+works correctly with unification hooks, propagation, and labeling.
+"""
+
+import pytest
+from prolog.engine.engine import Engine, Program
+
+
+class TestSimpleConstraintProblems:
+    """Test simple but realistic constraint problems."""
+
+    def test_send_more_money_digits(self):
+        """Classic SEND + MORE = MONEY cryptarithmetic (simplified to just digits)."""
+        engine = Engine(Program([]))
+
+        # Simplified version - just ensure different digits
+        query = """
+        ?- S in 1..9, E in 0..9, N in 0..9, D in 0..9,
+           M in 1..9, O in 0..9, R in 0..9, Y in 0..9,
+           S #\\= E, S #\\= N, S #\\= D, S #\\= M, S #\\= O, S #\\= R, S #\\= Y,
+           E #\\= N, E #\\= D, E #\\= M, E #\\= O, E #\\= R, E #\\= Y,
+           N #\\= D, N #\\= M, N #\\= O, N #\\= R, N #\\= Y,
+           D #\\= M, D #\\= O, D #\\= R, D #\\= Y,
+           M #\\= O, M #\\= R, M #\\= Y,
+           O #\\= R, O #\\= Y,
+           R #\\= Y,
+           label([S, E, N, D, M, O, R, Y]).
+        """
+        solutions = list(engine.query(query))
+
+        # Should find valid assignments where all variables are different
+        assert len(solutions) > 0
+
+        # Check that all values are indeed different
+        sol = solutions[0]
+        values = [sol[v].value for v in ['S', 'E', 'N', 'D', 'M', 'O', 'R', 'Y']]
+        assert len(set(values)) == 8  # All different
+
+    def test_simple_scheduling(self):
+        """Simple scheduling problem with precedence constraints."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- Start1 in 0..10, Start2 in 0..10, Start3 in 0..10,
+           Duration1 = 3, Duration2 = 2, Duration3 = 4,
+           End1 #= Start1 + Duration1,
+           End2 #= Start2 + Duration2,
+           End3 #= Start3 + Duration3,
+           End1 #=< Start2,
+           End2 #=< Start3,
+           End3 #=< 15,
+           label([Start1, Start2, Start3]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # Verify precedence constraints
+        for sol in solutions:
+            s1 = sol['Start1'].value
+            s2 = sol['Start2'].value
+            s3 = sol['Start3'].value
+            assert s1 + 3 <= s2  # Task 1 must finish before Task 2 starts
+            assert s2 + 2 <= s3  # Task 2 must finish before Task 3 starts
+            assert s3 + 4 <= 15  # Task 3 must finish by time 15
+
+    def test_magic_square_3x3_sum(self):
+        """3x3 magic square - all rows, columns, diagonals sum to same value."""
+        engine = Engine(Program([]))
+
+        # Simplified: just test that we can set up the constraints
+        # Full magic square would need sum constraints which we haven't implemented yet
+        query = """
+        ?- A in 1..9, B in 1..9, C in 1..9,
+           D in 1..9, E in 1..9, F in 1..9,
+           G in 1..9, H in 1..9, I in 1..9,
+           A #\\= B, A #\\= C, A #\\= D, A #\\= E, A #\\= F, A #\\= G, A #\\= H, A #\\= I,
+           B #\\= C, B #\\= D, B #\\= E, B #\\= F, B #\\= G, B #\\= H, B #\\= I,
+           C #\\= D, C #\\= E, C #\\= F, C #\\= G, C #\\= H, C #\\= I,
+           D #\\= E, D #\\= F, D #\\= G, D #\\= H, D #\\= I,
+           E #\\= F, E #\\= G, E #\\= H, E #\\= I,
+           F #\\= G, F #\\= H, F #\\= I,
+           G #\\= H, G #\\= I,
+           H #\\= I,
+           label([A, B, C, D, E, F, G, H, I]).
+        """
+        solutions = list(engine.query(query))
+
+        # Should find permutations of 1..9
+        assert len(solutions) > 0
+        sol = solutions[0]
+        values = [sol[v].value for v in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']]
+        assert set(values) == set(range(1, 10))
+
+
+class TestChainPropagation:
+    """Test scenarios with chains of propagating constraints."""
+
+    def test_linear_chain_propagation(self):
+        """Linear chain of less-than constraints."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- A in 1..20, B in 1..20, C in 1..20, D in 1..20, E in 1..20,
+           A #< B, B #< C, C #< D, D #< E,
+           C = 10.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # C = 10 should propagate both ways
+        assert sol['C'].value == 10
+
+        # A and B should be constrained to less than 10
+        from prolog.clpfd.api import get_domain
+        a_dom = get_domain(engine.store, sol['A'].id)
+        b_dom = get_domain(engine.store, sol['B'].id)
+        assert a_dom.max() < 10
+        assert b_dom.max() < 10
+        assert b_dom.min() > a_dom.min()  # B > A
+
+        # D and E should be constrained to greater than 10
+        d_dom = get_domain(engine.store, sol['D'].id)
+        e_dom = get_domain(engine.store, sol['E'].id)
+        assert d_dom.min() > 10
+        assert e_dom.min() > 10
+        assert e_dom.min() > d_dom.min()  # E > D
+
+    def test_diamond_propagation(self):
+        """Diamond-shaped constraint network."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- Top in 1..20, Left in 1..20, Right in 1..20, Bottom in 1..20,
+           Top #< Left, Top #< Right,
+           Left #< Bottom, Right #< Bottom,
+           Top = 5, Bottom = 15.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Top = 5, Bottom = 15
+        assert sol['Top'].value == 5
+        assert sol['Bottom'].value == 15
+
+        # Left and Right should be between 5 and 15
+        from prolog.clpfd.api import get_domain
+        left_dom = get_domain(engine.store, sol['Left'].id)
+        right_dom = get_domain(engine.store, sol['Right'].id)
+
+        assert left_dom.min() > 5  # > Top
+        assert left_dom.max() < 15  # < Bottom
+        assert right_dom.min() > 5
+        assert right_dom.max() < 15
+
+    def test_propagation_with_equality_chains(self):
+        """Test propagation through equality constraints."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- A in 1..20, B in 1..20, C in 1..20, D in 1..20,
+           A #= B, B #= C, C #= D,
+           A #< 10, D #> 5.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # All should have domain 6..9 (intersection of constraints)
+        from prolog.clpfd.api import get_domain
+        for var in ['A', 'B', 'C', 'D']:
+            dom = get_domain(engine.store, sol[var].id)
+            assert dom.min() == 6
+            assert dom.max() == 9
+
+
+class TestLabelingWithConstraints:
+    """Test labeling strategies in presence of constraints."""
+
+    def test_first_fail_with_constraints(self):
+        """First-fail should choose most constrained variable first."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- A in 1..100, B in 45..55, C in 1..100,
+           A #< B, B #< C,
+           labeling([first_fail], [A, B, C]).
+        """
+        solutions = list(engine.query(query))
+
+        # Should find solutions
+        assert len(solutions) > 0
+
+        # B has smallest domain, so should be labeled first
+        # This should lead to efficient search
+
+    def test_indomain_split_bisection(self):
+        """Test indomain_split bisection strategy."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..8, X #> 3, X #< 7,
+           labeling([indomain_split], [X]).
+        """
+        solutions = list(engine.query(query))
+
+        # Should find all values in 4..6
+        values = sorted([sol['X'].value for sol in solutions])
+        assert values == [4, 5, 6]
+
+    def test_most_constrained_selection(self):
+        """Most constrained variable selection strategy."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- A in 1..10, B in 1..10, C in 1..10,
+           A #< B, B #< C, A #< C,
+           labeling([most_constrained], [A, B, C]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # Verify all solutions satisfy constraints
+        for sol in solutions:
+            a = sol['A'].value
+            b = sol['B'].value
+            c = sol['C'].value
+            assert a < b < c
+
+
+class TestMixedConstraintsAndUnification:
+    """Test scenarios mixing CLP(FD) constraints with regular unification."""
+
+    def test_structure_with_fd_variables(self):
+        """FD variables in structures with unification."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 5..15, Y in 10..20,
+           Point = point(X, Y),
+           Point = point(A, B),
+           A #< B,
+           A = 10.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # X and A are unified and equal to 10
+        assert sol['X'].value == 10
+        assert sol['A'].value == 10
+
+        # Y and B are unified and > 10
+        from prolog.clpfd.api import get_domain
+        y_dom = get_domain(engine.store, sol['Y'].id)
+        assert y_dom.min() > 10
+
+    def test_list_of_fd_variables(self):
+        """Lists containing FD variables."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..5, Y in 3..7, Z in 5..9,
+           List = [X, Y, Z],
+           List = [A, B, C],
+           A #< B, B #< C,
+           label([A, B, C]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # Check all solutions have increasing values
+        for sol in solutions:
+            values = [sol[v].value for v in ['A', 'B', 'C']]
+            assert values[0] < values[1] < values[2]
+
+    def test_partial_grounding_with_constraints(self):
+        """Partial grounding through unification with constraint propagation."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 1..10, Z in 1..10,
+           triple(X, Y, Z) = triple(3, B, C),
+           B #> X, C #> B,
+           label([B, C]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # X should be grounded to 3
+        # B should be > 3
+        # C should be > B
+        for sol in solutions:
+            assert sol['X'].value == 3
+            assert sol['B'].value > 3
+            assert sol['C'].value > sol['B'].value
+
+
+class TestComplexScenarios:
+    """Test more complex real-world-like scenarios."""
+
+    def test_sudoku_row_constraint(self):
+        """Single Sudoku row constraint (all different)."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- A in 1..9, B in 1..9, C in 1..9, D in 1..9,
+           E in 1..9, F in 1..9, G in 1..9, H in 1..9, I in 1..9,
+           A #\\= B, A #\\= C, A #\\= D, A #\\= E, A #\\= F, A #\\= G, A #\\= H, A #\\= I,
+           B #\\= C, B #\\= D, B #\\= E, B #\\= F, B #\\= G, B #\\= H, B #\\= I,
+           C #\\= D, C #\\= E, C #\\= F, C #\\= G, C #\\= H, C #\\= I,
+           D #\\= E, D #\\= F, D #\\= G, D #\\= H, D #\\= I,
+           E #\\= F, E #\\= G, E #\\= H, E #\\= I,
+           F #\\= G, F #\\= H, F #\\= I,
+           G #\\= H, G #\\= I,
+           H #\\= I,
+           A = 5, I = 9,
+           label([B, C, D, E, F, G, H]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # Check solution validity
+        sol = solutions[0]
+        values = [sol[v].value for v in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']]
+        assert len(set(values)) == 9  # All different
+        assert set(values) == set(range(1, 10))  # Exactly 1..9
+        assert sol['A'].value == 5
+        assert sol['I'].value == 9
+
+    def test_graph_coloring_triangle(self):
+        """Simple graph coloring for triangle (3 nodes, all connected)."""
+        engine = Engine(Program([]))
+
+        # Three nodes, each needs different color from neighbors
+        query = """
+        ?- Red = 1, Green = 2, Blue = 3,
+           Node1 in 1..3, Node2 in 1..3, Node3 in 1..3,
+           Node1 #\\= Node2, Node2 #\\= Node3, Node1 #\\= Node3,
+           label([Node1, Node2, Node3]).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # Each solution should have all three different colors
+        for sol in solutions:
+            colors = [sol[f'Node{i}'].value for i in range(1, 4)]
+            assert len(set(colors)) == 3
+
+    def test_bin_packing_simple(self):
+        """Simple bin packing - items must fit in bins with capacity."""
+        engine = Engine(Program([]))
+
+        # 3 items with sizes, 2 bins with capacity 10
+        query = """
+        ?- Item1Size = 4, Item2Size = 3, Item3Size = 5,
+           BinCapacity = 10,
+           Item1Bin in 1..2, Item2Bin in 1..2, Item3Bin in 1..2,
+           label([Item1Bin, Item2Bin, Item3Bin]).
+        """
+        solutions = list(engine.query(query))
+
+        # Should find valid assignments
+        assert len(solutions) > 0
+
+        # Note: Without sum constraints, we can't enforce capacity
+        # This just tests that basic structure works

--- a/prolog/tests/unit/test_clpfd_hooks.py
+++ b/prolog/tests/unit/test_clpfd_hooks.py
@@ -1,0 +1,324 @@
+"""Tests for CLP(FD) unification hooks - Phase 6 of Issue #126.
+
+Tests the integration of CLP(FD) with attributed variable unification,
+including domain merging for var-var aliasing and var-int grounding.
+"""
+
+import pytest
+from prolog.ast.terms import Atom, Int, Var, Struct, List
+from prolog.engine.engine import Engine, Program
+from prolog.unify.unify import unify, bind
+from prolog.clpfd.api import get_domain, set_domain
+from prolog.clpfd.domain import Domain
+
+
+class TestCLPFDUnificationHooks:
+    """Test CLP(FD) behavior during unification."""
+
+    def test_var_var_domain_intersection(self):
+        """X in 1..10, Y in 5..15, X = Y should result in both having domain 5..10."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 1..10, Y in 5..15, X = Y."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Both X and Y should have the intersected domain 5..10
+        # After unification, they are aliased so checking one is sufficient
+        x_val = sol['X']
+        y_val = sol['Y']
+
+        # They should be the same variable after unification
+        assert x_val.id == y_val.id
+
+        # The domain should be the intersection
+        x_domain = get_domain(engine.store, x_val.id)
+        assert x_domain is not None
+        assert x_domain.min() == 5
+        assert x_domain.max() == 10
+
+    def test_var_var_empty_intersection_fails(self):
+        """X in 1..5, Y in 10..15, X = Y should fail due to empty intersection."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 1..5, Y in 10..15, X = Y."
+        solutions = list(engine.query(query))
+
+        # Should fail - no solutions
+        assert len(solutions) == 0
+
+    def test_var_int_domain_membership_success(self):
+        """X in 5..10, X = 7 should succeed with X bound to 7."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..10, X = 7."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        assert solutions[0]['X'].value == 7
+
+    def test_var_int_domain_membership_failure(self):
+        """X in 5..10, X = 3 should fail since 3 is not in domain."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..10, X = 3."
+        solutions = list(engine.query(query))
+
+        # Should fail - no solutions
+        assert len(solutions) == 0
+
+    def test_var_var_watchers_merge(self):
+        """Watchers should be merged when variables are aliased."""
+        engine = Engine(Program([]))
+
+        # Set up constraints that create watchers
+        query = """
+        ?- X in 1..10, Y in 5..15,
+           X #< Z, Y #> W,
+           Z in 1..20, W in 1..20,
+           X = Y.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) > 0
+
+        # After X = Y, the unified variable should have watchers from both
+        sol = solutions[0]
+        unified_var = sol['X']  # X and Y are now the same
+
+        # Check that constraints are still enforced
+        # X (now unified with Y) should be constrained by both X #< Z and Y #> W
+        # This means the domain should satisfy both constraints
+
+    def test_grounding_triggers_propagation(self):
+        """Grounding a variable should trigger propagation to dependent constraints."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 1..10,
+           X #< Y,
+           X = 5.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # X should be 5
+        assert sol['X'].value == 5
+
+        # Y should be pruned to 6..10 due to propagation
+        y_domain = get_domain(engine.store, sol['Y'].id)
+        assert y_domain is not None
+        assert y_domain.min() == 6
+        assert y_domain.max() == 10
+
+    def test_backtracking_restores_domains(self):
+        """Backtracking should restore original domains."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 5..15,
+           (X = Y, X #< 7 ; X #> 8).
+        """
+        solutions = list(engine.query(query))
+
+        # Should get two solution branches:
+        # 1. X = Y with intersected domain, then X #< 7
+        # 2. X #> 8 (without the unification)
+        assert len(solutions) == 2
+
+    def test_hook_preserves_non_clpfd_unification(self):
+        """Hook should not interfere with regular unification."""
+        engine = Engine(Program([]))
+
+        # Regular unification without CLP(FD)
+        query = "?- X = Y, Y = foo(bar, Z), Z = 42."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+        assert sol['X'].functor == 'foo'
+        assert sol['Y'].functor == 'foo'
+        assert sol['Z'].value == 42
+
+    def test_multiple_domain_merges(self):
+        """Chain of unifications should properly merge all domains."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..20, Y in 5..25, Z in 10..30,
+           X = Y, Y = Z.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # All three should be aliased to the same variable
+        assert sol['X'].id == sol['Y'].id == sol['Z'].id
+
+        # Domain should be intersection of all three: 10..20
+        domain = get_domain(engine.store, sol['X'].id)
+        assert domain is not None
+        assert domain.min() == 10
+        assert domain.max() == 20
+
+    def test_domain_update_on_both_vars_before_union(self):
+        """Critical: Both variables must be updated before union to avoid lost updates."""
+        engine = Engine(Program([]))
+
+        # This tests the critical guardrail that both variables get the merged
+        # domain BEFORE they are unified, preventing lost domain updates
+        query = """
+        ?- X in 1..10, Y in 5..15,
+           X = Y,
+           X in 6..9.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Final domain should be 6..9 (further constrained after unification)
+        domain = get_domain(engine.store, sol['X'].id)
+        assert domain is not None
+        assert domain.min() == 6
+        assert domain.max() == 9
+
+
+class TestCLPFDPropagationAfterUnification:
+    """Test that propagation runs correctly after unification events."""
+
+    def test_unification_triggers_propagation_queue(self):
+        """Unification should trigger propagation of all affected constraints."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 1..10, Z in 1..10,
+           X #< Y, Y #< Z,
+           X = 5.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # X = 5 should propagate to Y and Z
+        assert sol['X'].value == 5
+
+        y_domain = get_domain(engine.store, sol['Y'].id)
+        assert y_domain.min() == 6  # Y > 5
+
+        z_domain = get_domain(engine.store, sol['Z'].id)
+        assert z_domain.min() == 7  # Z > Y > 5, so Z >= 7
+
+    def test_var_var_unification_propagates_to_both_sets_of_watchers(self):
+        """When X=Y, watchers from both should be triggered."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 1..10, A in 1..10, B in 1..10,
+           X #< A, Y #< B,
+           X = Y, X = 5.
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Both A and B should be affected by X=Y=5
+        a_domain = get_domain(engine.store, sol['A'].id)
+        b_domain = get_domain(engine.store, sol['B'].id)
+
+        assert a_domain.min() == 6  # A > X = 5
+        assert b_domain.min() == 6  # B > Y = X = 5
+
+    def test_failed_unification_preserves_domains(self):
+        """Failed unification should not modify domains."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..5, Y in 10..15,
+           (X = Y -> true ; (X in 2..4, Y in 11..14)).
+        """
+        solutions = list(engine.query(query))
+
+        # Unification fails, so we take the else branch
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        x_domain = get_domain(engine.store, sol['X'].id)
+        y_domain = get_domain(engine.store, sol['Y'].id)
+
+        # Domains should be from the else branch
+        assert x_domain.min() == 2 and x_domain.max() == 4
+        assert y_domain.min() == 11 and y_domain.max() == 14
+
+
+class TestCLPFDHookEdgeCases:
+    """Test edge cases and error conditions in CLP(FD) hooks."""
+
+    def test_singleton_domain_unification(self):
+        """Unifying variables with singleton domains."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..5, Y in 5..5, X = Y."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        assert solutions[0]['X'].value == 5
+        assert solutions[0]['Y'].value == 5
+
+    def test_singleton_domain_conflict(self):
+        """Unifying variables with different singleton domains should fail."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..5, Y in 7..7, X = Y."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 0
+
+    def test_empty_domain_unification(self):
+        """Variables with empty domains (should already have failed)."""
+        engine = Engine(Program([]))
+
+        # This should fail at the domain posting stage
+        query = "?- X in 2..1."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 0
+
+    def test_unification_with_non_fd_variable(self):
+        """Unifying FD variable with regular variable."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..10, X = Y, Y = 7."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        assert solutions[0]['X'].value == 7
+        assert solutions[0]['Y'].value == 7
+
+    def test_cyclic_constraint_after_unification(self):
+        """Ensure no infinite loops when variables involved in mutual constraints are unified."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..10, Y in 1..10,
+           X #=< Y, Y #=< X,
+           X = Y.
+        """
+        solutions = list(engine.query(query))
+
+        # X #=< Y and Y #=< X means X = Y (equality constraint)
+        # So unifying them should succeed
+        assert len(solutions) == 1
+
+        # They remain as unbound FD variables with domain 1..10
+        sol = solutions[0]
+        assert sol['X'].id == sol['Y'].id
+        domain = get_domain(engine.store, sol['X'].id)
+        assert domain.min() == 1 and domain.max() == 10

--- a/prolog/tests/unit/test_clpfd_properties.py
+++ b/prolog/tests/unit/test_clpfd_properties.py
@@ -1,0 +1,344 @@
+"""Property-based tests for CLP(FD) - Phase 6 of Issue #126.
+
+Tests important properties like confluence, monotonicity, trail invertibility,
+and idempotence using Hypothesis for property-based testing.
+"""
+
+import pytest
+from hypothesis import given, strategies as st, settings, assume
+import random
+from prolog.ast.terms import Atom, Int, Var, Struct, List
+from prolog.engine.engine import Engine, Program
+from prolog.clpfd.api import get_domain, set_domain
+from prolog.clpfd.domain import Domain
+
+
+class TestCLPFDConfluence:
+    """Test that constraint posting order doesn't affect final result."""
+
+    @given(
+        constraints=st.lists(
+            st.sampled_from([
+                "X in 1..20",
+                "Y in 5..25",
+                "Z in 10..30",
+                "X #< Y",
+                "Y #< Z",
+                "X #> 3",
+                "Y #=< 20",
+                "Z #>= 15",
+            ]),
+            min_size=2,
+            max_size=6,
+        ),
+        seed=st.integers(min_value=0, max_value=1000)
+    )
+    @settings(max_examples=50, deadline=5000)
+    def test_confluence_different_posting_orders(self, constraints, seed):
+        """Random constraint posting order should yield same fixpoint."""
+        # Skip if we have conflicting constraints
+        if "X #< Y" in constraints and "Y #< X" in constraints:
+            assume(False)
+
+        # Create a deterministic shuffled version
+        rng = random.Random(seed)
+        shuffled_constraints = constraints.copy()
+        rng.shuffle(shuffled_constraints)
+
+        # Execute in original order
+        engine1 = Engine(Program([]))
+        query1 = "?- " + ", ".join(constraints) + "."
+        solutions1 = list(engine1.query(query1))
+
+        # Execute in shuffled order
+        engine2 = Engine(Program([]))
+        query2 = "?- " + ", ".join(shuffled_constraints) + "."
+        solutions2 = list(engine2.query(query2))
+
+        # Both should either succeed or fail together
+        assert len(solutions1) == len(solutions2)
+
+        if solutions1:
+            # If successful, check domains are the same
+            sol1 = solutions1[0]
+            sol2 = solutions2[0]
+
+            for var_name in ['X', 'Y', 'Z']:
+                if var_name in sol1 and var_name in sol2:
+                    dom1 = get_domain(engine1.store, sol1[var_name].id)
+                    dom2 = get_domain(engine2.store, sol2[var_name].id)
+
+                    if dom1 and dom2:
+                        # Compare domains (ignoring revision numbers)
+                        assert dom1.intervals == dom2.intervals
+
+    def test_confluence_specific_reordering(self):
+        """Test specific constraint reorderings for confluence."""
+        test_cases = [
+            # Original vs reversed
+            (["X in 1..10", "Y in 5..15", "X #< Y", "X #> 3"],
+             ["X #> 3", "X #< Y", "Y in 5..15", "X in 1..10"]),
+
+            # Interleaved vs grouped
+            (["X in 1..20", "X #< Y", "Y in 1..20", "Y #< Z", "Z in 1..20"],
+             ["X in 1..20", "Y in 1..20", "Z in 1..20", "X #< Y", "Y #< Z"]),
+        ]
+
+        for original, reordered in test_cases:
+            engine1 = Engine(Program([]))
+            query1 = "?- " + ", ".join(original) + "."
+            sols1 = list(engine1.query(query1))
+
+            engine2 = Engine(Program([]))
+            query2 = "?- " + ", ".join(reordered) + "."
+            sols2 = list(engine2.query(query2))
+
+            assert len(sols1) == len(sols2)
+
+
+class TestCLPFDMonotonicity:
+    """Test that domains only shrink, never expand."""
+
+    def test_domain_never_expands(self):
+        """Adding constraints should only shrink domains, never expand them."""
+        engine = Engine(Program([]))
+
+        # Start with initial domain
+        query1 = "?- X in 1..100."
+        sols1 = list(engine.query(query1))
+        initial_domain = get_domain(engine.store, sols1[0]['X'].id)
+
+        # Add constraint
+        query2 = "?- X in 1..100, X #> 50."
+        sols2 = list(engine.query(query2))
+        constrained_domain = get_domain(engine.store, sols2[0]['X'].id)
+
+        # Domain should have shrunk
+        assert constrained_domain.min() >= initial_domain.min()
+        assert constrained_domain.max() <= initial_domain.max()
+        assert constrained_domain.size() < initial_domain.size()
+
+        # Add another constraint
+        query3 = "?- X in 1..100, X #> 50, X #< 75."
+        sols3 = list(engine.query(query3))
+        further_constrained = get_domain(engine.store, sols3[0]['X'].id)
+
+        # Should shrink further
+        assert further_constrained.min() >= constrained_domain.min()
+        assert further_constrained.max() <= constrained_domain.max()
+        assert further_constrained.size() < constrained_domain.size()
+
+    @given(
+        initial_min=st.integers(min_value=1, max_value=50),
+        initial_max=st.integers(min_value=51, max_value=100),
+        constraint_value=st.integers(min_value=1, max_value=100)
+    )
+    @settings(max_examples=50, deadline=5000)
+    def test_monotonic_constraint_addition(self, initial_min, initial_max, constraint_value):
+        """Property: adding constraints monotonically shrinks domains."""
+        engine = Engine(Program([]))
+
+        # Initial domain
+        query = f"?- X in {initial_min}..{initial_max}."
+        sols = list(engine.query(query))
+
+        if not sols:
+            return  # Invalid domain
+
+        initial_domain = get_domain(engine.store, sols[0]['X'].id)
+        initial_size = initial_domain.size()
+
+        # Add various constraints and check monotonicity
+        constraint_queries = [
+            f"?- X in {initial_min}..{initial_max}, X #> {constraint_value}.",
+            f"?- X in {initial_min}..{initial_max}, X #< {constraint_value}.",
+            f"?- X in {initial_min}..{initial_max}, X #>= {constraint_value}.",
+            f"?- X in {initial_min}..{initial_max}, X #=< {constraint_value}.",
+        ]
+
+        for query in constraint_queries:
+            engine = Engine(Program([]))
+            sols = list(engine.query(query))
+
+            if sols:
+                new_domain = get_domain(engine.store, sols[0]['X'].id)
+                # Domain should never expand
+                assert new_domain.size() <= initial_size
+
+
+class TestCLPFDTrailInvertibility:
+    """Test that backtracking correctly restores state."""
+
+    def test_backtracking_restores_exact_domain(self):
+        """Backtracking should restore exact domain state."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..20,
+           (X #< 10, X #> 5, fail ; X #> 15).
+        """
+        solutions = list(engine.query(query))
+
+        # First branch fails, second succeeds
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Domain should be from second branch only
+        domain = get_domain(engine.store, sol['X'].id)
+        assert domain.min() == 16
+        assert domain.max() == 20
+
+    def test_nested_backtracking_restoration(self):
+        """Nested choice points should properly restore domains."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..30,
+           (
+               (X #< 10, X #> 7, fail) ;
+               (X in 15..25, (X #< 18, fail ; X #> 20))
+           ).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        sol = solutions[0]
+
+        # Should have domain 21..25 (from successful branch)
+        domain = get_domain(engine.store, sol['X'].id)
+        assert domain.min() == 21
+        assert domain.max() == 25
+
+    @given(
+        domain_ranges=st.lists(
+            st.tuples(
+                st.integers(min_value=1, max_value=50),
+                st.integers(min_value=51, max_value=100)
+            ),
+            min_size=2,
+            max_size=4
+        )
+    )
+    @settings(max_examples=30, deadline=5000)
+    def test_trail_restoration_property(self, domain_ranges):
+        """Property: trail correctly restores domains on backtracking."""
+        engine = Engine(Program([]))
+
+        # Build a query with multiple choice points
+        branches = []
+        for i, (low, high) in enumerate(domain_ranges[:-1]):
+            branches.append(f"(X in {low}..{high}, fail)")
+
+        # Last branch succeeds
+        last_low, last_high = domain_ranges[-1]
+        branches.append(f"X in {last_low}..{last_high}")
+
+        query = f"?- X in 1..100, ({' ; '.join(branches)})."
+        solutions = list(engine.query(query))
+
+        if solutions:
+            sol = solutions[0]
+            domain = get_domain(engine.store, sol['X'].id)
+
+            # Should have the domain from the last (successful) branch
+            assert domain.min() == last_low
+            assert domain.max() == last_high
+
+
+class TestCLPFDIdempotence:
+    """Test that posting the same constraint multiple times is safe."""
+
+    def test_duplicate_domain_posting(self):
+        """Posting the same domain constraint twice should be idempotent."""
+        engine = Engine(Program([]))
+
+        query = "?- X in 5..15, X in 5..15."
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        domain = get_domain(engine.store, solutions[0]['X'].id)
+        assert domain.min() == 5
+        assert domain.max() == 15
+
+    def test_duplicate_constraint_posting(self):
+        """Posting the same constraint twice should be idempotent."""
+        test_cases = [
+            "?- X in 1..20, Y in 1..20, X #< Y, X #< Y.",
+            "?- X in 1..20, X #> 5, X #> 5.",
+            "?- X in 1..20, Y in 1..20, X #= Y, X #= Y.",
+        ]
+
+        for query in test_cases:
+            engine = Engine(Program([]))
+            solutions = list(engine.query(query))
+
+            # Should still have solutions (constraints don't conflict with themselves)
+            assert len(solutions) > 0
+
+    @given(
+        constraint=st.sampled_from([
+            "X #> 5", "X #< 15", "X #>= 7", "X #=< 12"
+        ]),
+        repetitions=st.integers(min_value=1, max_value=5)
+    )
+    @settings(max_examples=30, deadline=5000)
+    def test_idempotent_constraint_property(self, constraint, repetitions):
+        """Property: repeating a constraint N times equals posting it once."""
+        # Post constraint once
+        engine1 = Engine(Program([]))
+        query1 = f"?- X in 1..20, {constraint}."
+        sols1 = list(engine1.query(query1))
+
+        # Post constraint multiple times
+        engine2 = Engine(Program([]))
+        constraints = ", ".join([constraint] * repetitions)
+        query2 = f"?- X in 1..20, {constraints}."
+        sols2 = list(engine2.query(query2))
+
+        # Should have same result
+        assert len(sols1) == len(sols2)
+
+        if sols1:
+            dom1 = get_domain(engine1.store, sols1[0]['X'].id)
+            dom2 = get_domain(engine2.store, sols2[0]['X'].id)
+            assert dom1.intervals == dom2.intervals
+
+
+class TestCLPFDMemoryProperties:
+    """Test that CLP(FD) doesn't leak memory on repeated operations."""
+
+    def test_repeated_post_backtrack_cycles(self):
+        """Repeated posting and backtracking shouldn't accumulate state."""
+        engine = Engine(Program([]))
+
+        # Run multiple cycles of constraint posting and backtracking
+        for _ in range(10):
+            query = """
+            ?- X in 1..100,
+               (X #< 50, X #> 25, fail ; X #> 75),
+               !.
+            """
+            solutions = list(engine.query(query))
+            assert len(solutions) == 1
+
+        # Store should not accumulate garbage
+        # (This is more of a sanity check - real memory testing needs profiling)
+        assert len(engine.store.cells) < 1000  # Reasonable upper bound
+
+    def test_no_watcher_accumulation(self):
+        """Watchers should be properly cleaned up on backtracking."""
+        engine = Engine(Program([]))
+
+        query = """
+        ?- X in 1..100, Y in 1..100, Z in 1..100,
+           (
+               (X #< Y, Y #< Z, Z #< 50, fail) ;
+               (X #> Y, Y #> Z, Z #> 50, fail) ;
+               X = 50
+           ).
+        """
+        solutions = list(engine.query(query))
+
+        assert len(solutions) == 1
+        # After backtracking through failed branches, watchers should be cleaned up
+        # The final solution should have minimal watchers


### PR DESCRIPTION
## Summary
Completes Stage 5 CLP(FD) implementation with unification hook integration and comprehensive property-based testing.

## What's Implemented

### Unification Hooks (`prolog/clpfd/hooks.py`)
- **Var-var aliasing**: Domain intersection with watcher merging
- **Var-int grounding**: Domain membership check with propagation
- **Critical guardrail**: Both variables updated before union
- **Auto-grounding**: Singleton domains automatically bind to value
- **Backtracking safety**: Failed unification preserves domains

### Additional Propagators
- **Not-equal** (`#\\=/2`): Disequality constraints with domain pruning
- **Sum-constant**: Arithmetic equality for `Z #= X + K` patterns

### Domain Persistence
- Solution variable domains preserved after query completion
- Enables `get_domain()` inspection in tests and debugging

## Test Results

### Unit Tests (✅ All passing)
- 18 hook tests covering all unification scenarios
- 12 property tests (confluence, monotonicity, idempotence)
- Full CLP(FD) suite: 205 tests passing

### Integration Scenarios (✅ 14/15 passing)
- ✅ Simple scheduling with precedence constraints
- ✅ Graph coloring (triangle)
- ✅ Sudoku row (all-different)
- ✅ Chain propagation (linear, diamond, equality)
- ✅ Mixed constraints with unification
- ⚠️ SEND+MORE (times out due to large search space)

## Performance Note
The SEND+MORE cryptarithmetic test with pairwise inequalities explores a large search space. Recommended solutions:
1. Use `labeling([most_constrained], Vars)` for better search
2. Implement `all_different/1` propagator for stronger pruning

## Files Changed
- **New**: `prolog/clpfd/hooks.py` - Unification hooks
- **New**: `prolog/clpfd/props/neq.py` - Not-equal propagator
- **New**: `prolog/clpfd/props/sum_const.py` - Sum-constant propagator
- **Modified**: `prolog/engine/builtins_clpfd.py` - Added `#\\=/2`, improved propagation
- **Modified**: `prolog/engine/engine.py` - Domain persistence, builtin registration
- **Modified**: `prolog/unify/unify_helpers.py` - Auto-grounding on singleton
- **Tests**: 3 new test files with comprehensive coverage

## Example Usage
```prolog
% Domain merging on unification
?- X in 1..10, Y in 5..15, X = Y.
% X and Y both get domain 5..10

% Grounding triggers propagation
?- X in 1..10, Y in 1..10, X #< Y, X = 5.
% Y automatically pruned to 6..10

% Property: confluence
?- X #< Y, Y #< Z, Z in 1..5.
% Same result as: Z in 1..5, Y #< Z, X #< Y.
```

Fixes #126