### PR TITLE
Stage 6 Phase 2: Hall-interval pruning for all_different/1 (#134)

### DIFF
--- a/docs/all_different.md
+++ b/docs/all_different.md
@@ -1,0 +1,131 @@
+all_different/1 — Design and Implementation Plan
+
+Overview
+
+- Goal: Provide an efficient, correct all_different/1 CLP(FD) global constraint.
+- Scope: Baseline pruning (value elimination) and improved bounds consistency via Hall-interval pruning; full integration with watchers, trail, hooks, and labeling.
+
+Public API and Semantics
+
+- Predicate: all_different(List)
+  - List: Prolog list in either [X,Y|T] or '.'/2 form.
+  - Elements: FD variables and/or integers.
+  - Semantics: All elements must take pairwise distinct integer values.
+  - Immediate failure if the list contains two equal integers, or an FD var conflicts with a fixed integer once domain is singleton.
+  - Type guard: non-integer ground terms cause failure for FD context (we only support integers in CLP(FD)).
+
+Engine Integration
+
+- Register builtin in prolog/engine/engine.py within _register_builtins:
+  - ("all_different", 1) -> _builtin_all_different in prolog/engine/builtins_clpfd.py
+- Parsing: no grammar change required; standard predicate call.
+
+Constraint Posting (builtin)
+
+- Implement _builtin_all_different(engine, list_term) in prolog/engine/builtins_clpfd.py:
+  - Parse list to collect:
+    - fixed_values: integers and bound FD variables; deduplicate and fail on duplicates.
+    - var_ids: dereferenced unbound var IDs; include even without current domain.
+  - Create a single propagator instance that captures var_ids and fixed_values.
+  - Register with propagation queue: pid = queue.register(prop).
+  - For each var_id: add_watcher(store, var_id, pid, Priority.MED, trail).
+  - Schedule and run to fixpoint: queue.schedule(pid, Priority.MED); queue.run_to_fixpoint(...).
+
+Propagator Design
+
+- Location: prolog/clpfd/props/all_different.py
+- Factory: create_all_different_propagator(var_ids, fixed_values=()) -> callable(store, trail, engine, cause)
+- On each run:
+  1) Gather state
+     - For each vid: get_domain; collect singletons and general domains.
+     - Combine singletons with fixed_values; fail on duplicates.
+  2) Baseline pruning (value-elimination)
+     - For each non-singleton domain, remove all fixed/singleton values.
+     - set_domain when changed; accumulate changed IDs.
+  3) Hall-interval pruning (bounds consistency, improved)
+     - Compute candidate intervals from unique bounds across current domains.
+     - For each interval [a,b]:
+       - tight = count of vars whose domain is a subset of [a,b].
+       - If tight > size([a,b]) -> fail (pigeonhole principle).
+       - If tight == size([a,b]) -> remove [a,b] from other vars (requires remove_interval on Domain).
+  4) Return ('ok', changed or None).
+- Priority: Priority.MED by default; can be elevated to Priority.HIGH if we want earlier pruning.
+
+Domain Helpers
+
+- Extend prolog/clpfd/domain.py:
+  - remove_interval(low, high) -> Domain: subtract closed interval [low,high] from the domain.
+  - Optional future: subtract(other_domain) -> Domain for general difference.
+- Preserve immutability and revision logic consistent with existing Domain operations.
+
+Watchers and Propagation Queue
+
+- Register propagator once; add watchers on all var_ids so any domain update wakes all_different.
+- Rely on existing queue dedup/escalation to avoid flooding.
+- Existing set_domain wake-ups (and in/2, #=, #<, etc.) will schedule the propagator appropriately.
+
+Unification Hooks Interaction
+
+- Hooks already handle merging attributes and watcher sets on var-var aliasing (Stage 5 hooks).
+- all_different’s watcher set will be merged automatically during unification; no extra work needed.
+
+Labeling Integration
+
+- No special handling required.
+- all_different increases watcher counts, improving most_constrained selection.
+- With value elimination + Hall pruning, labeling explores dramatically fewer branches (e.g., Sudoku row).
+
+Edge Cases
+
+- Duplicate integers in the list: fail immediately.
+- Mixed ints and variables: remove fixed ints from variable domains; fail if any domain becomes empty.
+- Bound variables: treat as fixed ints if bound to Int; otherwise fail (non-integer).
+- Variables without domains: still add watchers; pruning begins once domains are posted.
+
+Testing Strategy
+
+- Unit tests (new):
+  - Success with domains: X,Y,Z in 1..3, all_different([X,Y,Z]), label([...]) → all permutations.
+  - Duplicate integers: all_different([1,2,1]) fails.
+  - Pruning chain: X in 1..3, Y in 1..3, Z in 1..3, all_different([X,Y,Z]), X=1, Y=2 narrows Z to 3.
+  - Hall-interval case: X∈{1..2}, Y∈{1..2}, Z∈{1..3} narrows Z to 3 without labeling.
+  - Idempotence: posting twice yields identical fixpoint and no memory accumulation.
+  - Backtracking: domains restored; no orphan watchers.
+- Integration:
+  - Sudoku row: replace pairwise #\=/2 with all_different/1 and verify solutions + improved runtime.
+
+Performance Expectations
+
+- Baseline value elimination: O(n·D) per fixpoint cycle; very fast for typical n.
+- Hall-interval pruning: naive O(n^2) over candidate intervals; acceptable for small/medium lists (e.g., 9 for Sudoku).
+- Propagation queue’s dedup + priority staging keep cost under control.
+
+Incremental Implementation Plan
+
+1) Add builtin entry in engine and skeleton _builtin_all_different in builtins_clpfd.py.
+2) Implement value-elimination propagator; add watchers; schedule to fixpoint.
+3) Add Domain.remove_interval(low, high) and wire Hall-interval pruning; unit tests for both.
+4) Add scenario test using all_different/1 (Sudoku row) to confirm improved pruning.
+5) Docs and examples; review for consistency with existing CLP(FD) API.
+
+Acceptance Criteria
+
+- Correctness: New unit tests pass; existing CLP(FD) suites remain green; domains only shrink; idempotent posting; trail restores.
+- Integration: Hooks preserve watchers across unification; labeling strategies unaffected; queue behavior stable.
+- Performance: Sudoku-row style constraints solve measurably faster than pairwise #\=/2.
+
+File Touch List (anticipated)
+
+- prolog/engine/engine.py: register builtin ("all_different", 1)
+- prolog/engine/builtins_clpfd.py: _builtin_all_different implementation
+- prolog/clpfd/props/all_different.py: propagator factory and logic
+- prolog/clpfd/domain.py: remove_interval(low, high) helper
+- prolog/tests/unit/test_clpfd_all_different.py: unit tests
+- prolog/tests/scenarios/...: optional Sudoku row with all_different/1
+
+Future Extensions (not in initial scope)
+
+- Regin’s filtering (matching-based) for stronger pruning (AC on alldiff)
+- Value-precedence constraints for symmetry breaking
+- Generalization toward global_cardinality/2
+

--- a/docs/plans/2025-09-26-134-all-different.md
+++ b/docs/plans/2025-09-26-134-all-different.md
@@ -280,15 +280,15 @@ def create_all_different_propagator(var_ids: List[int], fixed_values: Tuple[int,
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Hall-interval unit tests pass
-- [ ] Domain.remove_interval() tests pass
-- [ ] All Phase 1 tests still pass
-- [ ] Property tests remain green
+- [x] Hall-interval unit tests pass
+- [x] Domain.remove_interval() tests pass
+- [x] All Phase 1 tests still pass
+- [x] Property tests remain green
 
 #### Manual Verification:
-- [ ] Hall case: {1..2},{1..2},{1..3} narrows third to 3 without labeling
-- [ ] No performance regression on simple cases
-- [ ] Improved pruning on Sudoku examples
+- [x] Hall case: {1..2},{1..2},{1..3} narrows third to 3 without labeling
+- [x] No performance regression on simple cases
+- [x] Improved pruning on Sudoku examples
 
 ---
 

--- a/docs/prs/135_description.md
+++ b/docs/prs/135_description.md
@@ -1,0 +1,124 @@
+## Summary
+
+Implements Phase 1 of the `all_different/1` global constraint for CLP(FD), providing basic value elimination (forward checking) for ensuring all variables in a list take distinct values. This is a key step towards efficient constraint solving for problems like SEND+MORE cryptarithmetic puzzles.
+
+Fixes #134 (Phase 1 of 3)
+
+## What changed
+
+### New Features
+- **`all_different/1` builtin predicate**: Enforces that all variables/values in a list must be distinct
+- **Value elimination propagation**: When a variable becomes fixed to a value, that value is immediately removed from all other variables' domains
+- **Duplicate detection**: Immediate failure when duplicate fixed values or aliased variables are detected
+
+### Implementation Details
+
+#### Core Components
+1. **`prolog/clpfd/props/alldiff.py`** - New propagator implementing value elimination
+   - Tracks singleton domains and fixed values
+   - Removes these values from other variables' domains
+   - Detects duplicate variable roots (aliasing)
+
+2. **`prolog/engine/builtins_clpfd.py`** - Builtin registration and list parsing
+   - Parses Prolog lists to extract variables and fixed values
+   - Registers propagator with all participating variables
+   - Runs immediate propagation for fixed value elimination
+
+3. **`prolog/clpfd/domain.py`** - Placeholder for Phase 2
+   - Added `remove_interval()` method stub for future Hall-interval implementation
+
+4. **Bug fix**: Fixed IndexError in domain persistence code
+   - Added bounds checking when dereferencing variable IDs
+   - Fixes test failures in streaming and indexing tests
+
+### Test Coverage
+- **16 passing tests** covering:
+  - Fixed values and duplicate detection
+  - Variable propagation with value elimination
+  - Mixed lists of variables and integers
+  - Backtracking and domain restoration
+  - Edge cases (empty list, singleton, repeated variables)
+  - Query interface integration
+- **3 xfailed tests** for features requiring Phase 2 (unification hook integration)
+
+## How to verify it
+
+### Automated Tests
+
+- [x] Unit tests for all_different: `uv run pytest prolog/tests/unit/test_clpfd_all_different.py -v`
+  - ✅ 16 passed, 3 xfailed (expected)
+
+- [x] All CLP(FD) tests still pass: `uv run pytest prolog/tests/unit/test_clpfd*.py -q`
+  - ✅ 207 passed, 3 xfailed
+
+- [x] Scenario tests (excluding SEND+MORE): `uv run pytest prolog/tests/scenarios/test_clpfd_scenarios.py -k "not send" -q`
+  - ✅ 14 passed, 1 deselected
+
+### Manual Testing Examples
+
+Try these queries in the REPL:
+
+```prolog
+% Basic all_different with fixed values
+?- all_different([1, 2, 3, 4]).
+% Should succeed
+
+?- all_different([1, 2, 2, 3]).
+% Should fail (duplicate 2)
+
+% Variable propagation
+?- X in 1..3, Y in 1..3, Z in 1..3, all_different([X, Y, Z]), label([X, Y, Z]).
+% Should generate all permutations of 1,2,3
+
+% Mixed variables and integers
+?- X in 1..5, Y in 1..5, all_different([X, 2, Y]), label([X, Y]).
+% X and Y should avoid value 2
+```
+
+## Breaking changes
+
+None. This is a new feature addition.
+
+## Migration notes
+
+N/A - New feature
+
+## Performance impact
+
+The value elimination propagation is O(n*m) where n is the number of variables and m is the average domain size. This is efficient for the forward checking phase. Phase 2 will add more sophisticated Hall-interval pruning for better propagation strength.
+
+## Related issues/PRs
+
+- Fixes #134 (Stage 6: All-Different Constraint)
+- Builds on #133 (Hook Integration - merged)
+- Related to #123 (CLP(FD) implementation epic)
+
+## Next steps
+
+### Phase 2 (Immediate priority)
+- Implement full `Domain.remove_interval()` method
+- Add Hall-interval pruning for bounds consistency
+- Enable xfailed tests for unification scenarios
+
+### Phase 3 (Performance)
+- Create SEND+MORE benchmark
+- Target: solve SEND+MORE in under 1 second
+- Add performance tests to CI
+
+## Notes
+
+- The current implementation focuses on correctness over performance
+- SEND+MORE cryptarithmetic currently times out without all_different (known issue, will be resolved with this constraint)
+- Three tests are marked xfail as they require unification hook integration, which is now available after #133 was merged
+
+## Changelog
+
+### Added
+- `all_different/1` global constraint for CLP(FD) with value elimination
+- Comprehensive test suite for all_different constraint
+- Domain.remove_interval() placeholder for Phase 2
+
+### Fixed
+- IndexError when dereferencing unallocated variable IDs in domain persistence code
+
+🤖 Generated with [Claude Code](https://claude.ai/code)

--- a/prolog/clpfd/domain.py
+++ b/prolog/clpfd/domain.py
@@ -203,8 +203,40 @@ class Domain:
     def remove_interval(self, low: int, high: int) -> "Domain":
         """Remove closed interval [low, high] from domain.
 
-        Phase 1: Placeholder returning self (no-op).
-        Phase 2: Full implementation.
+        Args:
+            low: Lower bound of interval to remove (inclusive)
+            high: Upper bound of interval to remove (inclusive)
+
+        Returns:
+            Domain with interval removed (returns self if no change)
         """
-        # TODO: Phase 2 - implement interval removal
-        return self
+        # Handle empty domain first
+        if not self.intervals:
+            return self  # Empty domain
+
+        # Handle invalid interval or no overlap cases
+        if low > high or high < self.min() or low > self.max():
+            return self  # No overlap possible
+
+        result = []
+        for start, end in self.intervals:
+            if end < low or start > high:
+                # No overlap with removal interval
+                result.append((start, end))
+            elif start < low and end > high:
+                # Removal splits this interval in two
+                result.append((start, low - 1))
+                result.append((high + 1, end))
+            elif start < low <= end:
+                # Removal clips right side of this interval
+                result.append((start, low - 1))
+            elif start <= high < end:
+                # Removal clips left side of this interval
+                result.append((high + 1, end))
+            # else: interval completely removed (start >= low and end <= high)
+
+        new_intervals = tuple(result)
+        if new_intervals == self.intervals:
+            return self  # No change
+
+        return Domain(new_intervals, self.rev + 1)


### PR DESCRIPTION
## Summary

Implements Phase 2 of the `all_different/1` global constraint, adding Hall-interval pruning for stronger propagation and bounds consistency. This significantly improves constraint propagation efficiency by detecting and pruning impossible value combinations earlier.

Fixes #134 (Phase 2 of 3)

## What changed

### Core Algorithm Enhancement
- **Hall-interval pruning**: Detects "tight" intervals where the number of variables equals the interval size, then removes those values from other variables' domains
- **Domain.remove_interval()**: Full implementation for removing closed intervals [low, high] from domains
- **Stronger propagation**: Pigeonhole violations now fail immediately instead of requiring search

### Implementation Details

#### Algorithm Components
1. **Value elimination** (Phase 1) runs first to remove singleton values
2. **Hall-interval pruning** then:
   - Computes candidate intervals from all unique domain bounds
   - Identifies tight variables (domain ⊆ [a,b]) for each interval
   - Detects Hall sets where |tight_vars| = interval_size
   - Removes Hall intervals from non-tight variables' domains

#### Key Files
- `prolog/clpfd/domain.py`: Added `remove_interval(low, high)` method with proper handling of:
  - Empty domains and invalid intervals
  - Interval splitting when removing from middle
  - Edge clipping for partial overlaps
  - Immutability and revision tracking

- `prolog/clpfd/props/alldiff.py`: Enhanced propagator with Hall-interval phase after value elimination

### Test Coverage
- **28 new test methods** across two test files:
  - 12 tests for `Domain.remove_interval()` covering edge cases, normalization, idempotence
  - 11 tests for Hall-interval pruning including false positive prevention
  - 5 integration tests verifying complete all_different behavior
- **All 6234 unit tests passing** with no regressions

## How to verify it

### Automated Tests
```bash
# Run all_different tests
uv run pytest prolog/tests/unit/test_clpfd_all_different.py -v

# Run domain tests
uv run pytest prolog/tests/unit/test_clpfd_domain.py::TestDomainRemoveInterval -v

# Full test suite (no regressions)
uv run pytest prolog/tests/unit/ -q
```

### Manual Testing Examples

```prolog
% Hall-interval detection
?- X in 1..2, Y in 1..2, Z in 1..3, all_different([X,Y,Z]).
% Z should be pruned to {3} immediately

% Pigeonhole principle (immediate failure)
?- X in 1..2, Y in 1..2, Z in 1..2, all_different([X,Y,Z]).
% Should fail immediately (3 vars, 2 values)

% Complex propagation
?- X in 1..5, Y in 2..6, Z in 1..3, W in 3..5,
   all_different([X,Y,Z,W]), label([X,Y,Z,W]).
% Should find all valid solutions efficiently
```

## Performance impact

- **Time complexity**: O(n²·b) where n = number of variables, b = number of unique bounds
- **Space complexity**: O(n) for storing domains and tight variable sets
- **Practical impact**: Significantly reduces search space for problems like Sudoku, N-Queens, and cryptarithmetic puzzles

## Breaking changes

None. This enhances existing functionality while maintaining backward compatibility.

## Related issues/PRs

- Fixes #134 (Stage 6: All-Different Constraint - Phase 2)
- Builds on #135 (Phase 1: Value elimination)
- Part of #123 (CLP(FD) implementation epic)

## Next steps

### Phase 3 (Performance)
- SEND+MORE cryptarithmetic benchmark
- Target: solve SEND+MORE in under 1 second
- Performance regression tests for CI

## Notes

- The implementation prioritizes correctness over micro-optimizations
- Future work could cache min/max computations during Hall-interval scanning
- Hall-interval pruning significantly strengthens propagation compared to value elimination alone