### PR TITLE
Phase 4: Core Reification Propagator for CLP(FD)

### DIFF
--- a/prolog/clpfd/props/reif.py
+++ b/prolog/clpfd/props/reif.py
@@ -1,0 +1,171 @@
+"""Reification propagator for CLP(FD) constraints."""
+
+from typing import Tuple, Optional, List, Callable
+
+from prolog.clpfd.boolean import get_boolean_value, ensure_boolean_var
+from prolog.clpfd.entailment import Entailment
+from prolog.clpfd.api import get_domain, set_domain
+from prolog.clpfd.domain import Domain
+
+
+def create_reification_propagator(
+    b_id: int,
+    constraint_type: str,
+    constraint_args: tuple,
+    check_entailment: Callable,
+    post_constraint: Callable,
+    post_negation: Callable,
+):
+    """Create a reification propagator for B #<==> Constraint.
+
+    Args:
+        b_id: Boolean variable ID
+        constraint_type: Type of constraint being reified
+        constraint_args: Arguments to the constraint
+        check_entailment: Function to check constraint entailment
+        post_constraint: Function to post the constraint
+        post_negation: Function to post constraint negation
+
+    Returns:
+        Propagator function
+    """
+    # Track if we've already posted to prevent loops
+    posted_true = [False]
+    posted_false = [False]
+
+    def reification_propagator(
+        store, trail, engine, cause
+    ) -> Tuple[str, Optional[List[int]]]:
+        """Propagate reification constraint B #<==> C.
+
+        Three rules:
+        1. If C is entailed, set B = 1
+        2. If C is dis-entailed, set B = 0
+        3. If B is determined:
+           - B = 1: post C
+           - B = 0: post ¬C
+        """
+        changed = []
+
+        # Ensure B has Boolean domain
+        if not ensure_boolean_var(store, b_id, trail):
+            return ("fail", None)
+
+        # Check current value of B
+        b_value = get_boolean_value(store, b_id)
+
+        # Check entailment of the constraint
+        entailment = check_entailment(store, *constraint_args)
+
+        # Rule 1 & 2: Update B based on constraint entailment
+        if entailment == Entailment.TRUE:
+            # Constraint is satisfied - B must be 1
+            b_dom = get_domain(store, b_id)
+            if b_dom and not b_dom.contains(1):
+                return ("fail", None)
+
+            if b_value != 1:
+                new_dom = Domain(((1, 1),))
+                set_domain(store, b_id, new_dom, trail)
+                changed.append(b_id)
+                b_value = 1
+
+        elif entailment == Entailment.FALSE:
+            # Constraint is violated - B must be 0
+            b_dom = get_domain(store, b_id)
+            if b_dom and not b_dom.contains(0):
+                return ("fail", None)
+
+            if b_value != 0:
+                new_dom = Domain(((0, 0),))
+                set_domain(store, b_id, new_dom, trail)
+                changed.append(b_id)
+                b_value = 0
+
+        # Rule 3: Post constraint based on B's value
+        if b_value == 1 and not posted_true[0]:
+            # B = 1: Post the constraint
+            posted_true[0] = True
+            success = post_constraint(engine, store, trail, *constraint_args)
+            if not success:
+                return ("fail", None)
+
+        elif b_value == 0 and not posted_false[0]:
+            # B = 0: Post the constraint's negation
+            posted_false[0] = True
+            success = post_negation(engine, store, trail, *constraint_args)
+            if not success:
+                return ("fail", None)
+
+        return ("ok", changed if changed else None)
+
+    return reification_propagator
+
+
+def create_implication_propagator(
+    b_id: int,
+    constraint_type: str,
+    constraint_args: tuple,
+    check_entailment: Callable,
+    post_constraint: Callable,
+    forward: bool = True,
+):
+    """Create propagator for B #==> C (forward) or B #<== C (backward).
+
+    Forward (B #==> C): If B=1 then C must hold
+    Backward (B #<== C): If C holds then B=1
+    """
+    posted = [False]
+
+    def implication_propagator(
+        store, trail, engine, cause
+    ) -> Tuple[str, Optional[List[int]]]:
+        changed = []
+
+        # Ensure B has Boolean domain
+        if not ensure_boolean_var(store, b_id, trail):
+            return ("fail", None)
+
+        b_value = get_boolean_value(store, b_id)
+        entailment = check_entailment(store, *constraint_args)
+
+        if forward:
+            # B #==> C: B=1 implies C
+            if b_value == 1 and not posted[0]:
+                posted[0] = True
+                success = post_constraint(engine, store, trail, *constraint_args)
+                if not success:
+                    return ("fail", None)
+
+            # If C is false, B must be 0
+            if entailment == Entailment.FALSE:
+                if b_value != 0:
+                    b_dom = get_domain(store, b_id)
+                    if b_dom and not b_dom.contains(0):
+                        return ("fail", None)
+                    new_dom = Domain(((0, 0),))
+                    set_domain(store, b_id, new_dom, trail)
+                    changed.append(b_id)
+        else:
+            # B #<== C: C implies B=1
+            if entailment == Entailment.TRUE:
+                if b_value != 1:
+                    b_dom = get_domain(store, b_id)
+                    if b_dom and not b_dom.contains(1):
+                        return ("fail", None)
+                    new_dom = Domain(((1, 1),))
+                    set_domain(store, b_id, new_dom, trail)
+                    changed.append(b_id)
+
+            # If B=0, C must be false (contrapositive)
+            if b_value == 0 and not posted[0]:
+                posted[0] = True
+                # For backward implication with B=0, we can't directly
+                # post ¬C in general. This is weaker than equivalence.
+                # We just fail if C is already entailed
+                if entailment == Entailment.TRUE:
+                    return ("fail", None)
+
+        return ("ok", changed if changed else None)
+
+    return implication_propagator

--- a/prolog/tests/unit/test_clpfd_reif.py
+++ b/prolog/tests/unit/test_clpfd_reif.py
@@ -1,0 +1,680 @@
+"""Unit tests for CLP(FD) reification propagators.
+
+Tests the core reification propagator for B #<==> C, B #==> C, and B #<== C.
+"""
+
+from prolog.unify.store import Store
+from prolog.unify.trail import Trail
+from prolog.unify.unify import bind
+from prolog.ast.terms import Int
+from prolog.clpfd.domain import Domain
+from prolog.clpfd.api import get_domain, set_domain
+from prolog.clpfd.boolean import get_boolean_value
+from prolog.clpfd.entailment import Entailment
+from prolog.clpfd.props.reif import (
+    create_reification_propagator,
+    create_implication_propagator,
+)
+
+
+class TestReificationPropagatorFactory:
+    """Test the create_reification_propagator factory function."""
+
+    def test_factory_creates_callable_propagator(self):
+        """Test that factory returns a callable propagator."""
+
+        def mock_check(store, x, y):
+            return Entailment.UNKNOWN
+
+        def mock_post(engine, store, trail, x, y):
+            return True
+
+        def mock_neg(engine, store, trail, x, y):
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=0,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=mock_check,
+            post_constraint=mock_post,
+            post_negation=mock_neg,
+        )
+
+        assert callable(propagator)
+
+    def test_propagator_ensures_boolean_domain(self):
+        """Test that propagator ensures B has Boolean domain."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        def mock_check(store, x, y):
+            return Entailment.UNKNOWN
+
+        def mock_post(engine, store, trail, x, y):
+            return True
+
+        def mock_neg(engine, store, trail, x, y):
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=mock_check,
+            post_constraint=mock_post,
+            post_negation=mock_neg,
+        )
+
+        # Propagator should ensure B has Boolean domain
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        b_dom = get_domain(store, b_id)
+        assert b_dom is not None
+        assert b_dom.min() == 0
+        assert b_dom.max() == 1
+
+
+class TestReificationBidirectionalPropagation:
+    """Test bidirectional propagation between B and constraint."""
+
+    def test_entailed_constraint_sets_b_to_1(self):
+        """When constraint is entailed, B should become 1."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+        x_id = store.new_var("X")
+
+        # X has singleton domain {5}
+        set_domain(store, x_id, Domain(((5, 5),)), trail)
+
+        def check_x_equals_5(store, x, y):
+            # Check X #= 5
+            x_dom = get_domain(store, x)
+            if x_dom and x_dom.is_singleton() and x_dom.min() == y[1]:
+                return Entailment.TRUE
+            return Entailment.UNKNOWN
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(x_id, (None, 5)),
+            check_entailment=check_x_equals_5,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        # Run propagator
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should be set to 1
+        b_value = get_boolean_value(store, b_id)
+        assert b_value == 1
+
+    def test_disentailed_constraint_sets_b_to_0(self):
+        """When constraint is dis-entailed, B should become 0."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+        x_id = store.new_var("X")
+
+        # X has domain that excludes 5
+        set_domain(store, x_id, Domain(((1, 4), (6, 10))), trail)
+
+        def check_x_equals_5(store, x, y):
+            # Check X #= 5
+            x_dom = get_domain(store, x)
+            if x_dom and not x_dom.contains(y[1]):
+                return Entailment.FALSE
+            return Entailment.UNKNOWN
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(x_id, (None, 5)),
+            check_entailment=check_x_equals_5,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        # Run propagator
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should be set to 0
+        b_value = get_boolean_value(store, b_id)
+        assert b_value == 0
+
+    def test_b_equals_1_posts_constraint(self):
+        """When B=1, the constraint should be posted."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+        x_id = store.new_var("X")
+
+        # Set B to 1
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        # Track if constraint was posted
+        posted = []
+
+        def track_post(engine, store, trail, x, y):
+            posted.append(("constraint", x, y))
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(x_id, (None, 5)),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=track_post,
+            post_negation=lambda *args: True,
+        )
+
+        # Run propagator
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # Constraint should have been posted
+        assert len(posted) == 1
+        assert posted[0][0] == "constraint"
+
+    def test_b_equals_0_posts_negation(self):
+        """When B=0, the constraint negation should be posted."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+        x_id = store.new_var("X")
+
+        # Set B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        # Track if negation was posted
+        posted = []
+
+        def track_neg(engine, store, trail, x, y):
+            posted.append(("negation", x, y))
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(x_id, (None, 5)),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=lambda *args: True,
+            post_negation=track_neg,
+        )
+
+        # Run propagator
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # Negation should have been posted
+        assert len(posted) == 1
+        assert posted[0][0] == "negation"
+
+
+class TestReificationLoopPrevention:
+    """Test prevention of infinite propagation loops."""
+
+    def test_constraint_posted_only_once(self):
+        """Constraint should only be posted once even if propagator runs multiple times."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 1
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        # Count posts
+        post_count = [0]
+
+        def counting_post(engine, store, trail, x, y):
+            post_count[0] += 1
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=counting_post,
+            post_negation=lambda *args: True,
+        )
+
+        # Run propagator multiple times
+        propagator(store, trail, None, None)
+        propagator(store, trail, None, None)
+        propagator(store, trail, None, None)
+
+        # Should have posted only once
+        assert post_count[0] == 1
+
+    def test_negation_posted_only_once(self):
+        """Negation should only be posted once even if propagator runs multiple times."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        # Count posts
+        neg_count = [0]
+
+        def counting_neg(engine, store, trail, x, y):
+            neg_count[0] += 1
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=lambda *args: True,
+            post_negation=counting_neg,
+        )
+
+        # Run propagator multiple times
+        propagator(store, trail, None, None)
+        propagator(store, trail, None, None)
+        propagator(store, trail, None, None)
+
+        # Should have posted negation only once
+        assert neg_count[0] == 1
+
+
+class TestAdditionalEdgeCases:
+    """Test additional edge cases for better coverage."""
+
+    def test_incompatible_boolean_domain(self):
+        """When B has incompatible domain (e.g., 2..5), should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to incompatible domain
+        set_domain(store, b_id, Domain(((2, 5),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        # Should fail because B can't be constrained to {0,1}
+        assert result[0] == "fail"
+
+    def test_bound_boolean_variables(self):
+        """Test reification with bound Boolean variables."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Bind B to Int(1) instead of using domain
+        bind(store, b_id, Int(1), trail)
+
+        # Track if constraint was posted
+        posted = []
+
+        def track_post(engine, store, trail, x, y):
+            posted.append(("constraint", x, y))
+            return True
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=track_post,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+        # Constraint should have been posted because B is bound to 1
+        assert len(posted) == 1
+
+    def test_forward_constraint_entailed_no_op(self):
+        """B #==> C: When C is already entailed, no forced change to B."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,
+            post_constraint=lambda *args: True,
+            forward=True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should still have full Boolean domain (not forced)
+        b_dom = get_domain(store, b_id)
+        assert b_dom.contains(0)
+        assert b_dom.contains(1)
+        # No changes should be returned
+        assert result[1] is None
+
+
+class TestImplicationPropagatorForward:
+    """Test forward implication B #==> C."""
+
+    def test_forward_b_1_posts_constraint(self):
+        """B #==> C: When B=1, constraint should be posted."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 1
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        posted = []
+
+        def track_post(engine, store, trail, x, y):
+            posted.append(("constraint", x, y))
+            return True
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=track_post,
+            forward=True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+        assert len(posted) == 1
+
+    def test_forward_constraint_false_sets_b_0(self):
+        """B #==> C: When C is false, B must be 0."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.FALSE,
+            post_constraint=lambda *args: True,
+            forward=True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should be 0
+        b_value = get_boolean_value(store, b_id)
+        assert b_value == 0
+
+    def test_forward_b_0_no_constraint(self):
+        """B #==> C: When B=0, constraint is not posted."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        posted = []
+
+        def track_post(engine, store, trail, x, y):
+            posted.append(("constraint", x, y))
+            return True
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=track_post,
+            forward=True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # Should not have posted constraint
+        assert len(posted) == 0
+
+
+class TestImplicationPropagatorBackward:
+    """Test backward implication B #<== C."""
+
+    def test_backward_constraint_true_sets_b_1(self):
+        """B #<== C: When C is true, B must be 1."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,
+            post_constraint=lambda *args: True,
+            forward=False,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should be 1
+        b_value = get_boolean_value(store, b_id)
+        assert b_value == 1
+
+    def test_backward_b_0_constraint_true_fails(self):
+        """B #<== C: When B=0 and C is entailed, should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,
+            post_constraint=lambda *args: True,
+            forward=False,
+        )
+
+        result = propagator(store, trail, None, None)
+        # Should fail because B=0 contradicts C being true
+        assert result[0] == "fail"
+
+    def test_backward_constraint_false_b_unconstrained(self):
+        """B #<== C: When C is false, B can be anything."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        propagator = create_implication_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.FALSE,
+            post_constraint=lambda *args: True,
+            forward=False,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+
+        # B should still be unconstrained (0 or 1)
+        b_dom = get_domain(store, b_id)
+        assert b_dom.contains(0)
+        assert b_dom.contains(1)
+
+
+class TestReificationFailureCases:
+    """Test failure cases in reification."""
+
+    def test_b_0_contradicts_entailment_true(self):
+        """When B=0 but constraint is entailed (true), should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Force B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,  # Constraint is true
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        # Should fail because B=0 contradicts entailed constraint
+        assert result[0] == "fail"
+
+    def test_b_1_contradicts_entailment_false(self):
+        """When B=1 but constraint is disentailed (false), should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Force B to 1
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.FALSE,  # Constraint is false
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        # Should fail because B=1 contradicts disentailed constraint
+        assert result[0] == "fail"
+
+    def test_posting_constraint_fails(self):
+        """When posting constraint fails, propagator should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 1
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=lambda *args: False,  # Posting fails
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "fail"
+
+    def test_posting_negation_fails(self):
+        """When posting negation fails, propagator should fail."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # Set B to 0
+        set_domain(store, b_id, Domain(((0, 0),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.UNKNOWN,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: False,  # Posting negation fails
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "fail"
+
+
+class TestChangedVariableTracking:
+    """Test that propagators correctly track changed variables."""
+
+    def test_b_changed_returned(self):
+        """When B's domain changes, it should be in the changed list."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+        assert result[1] == [b_id]  # B was changed
+
+    def test_no_change_returns_none(self):
+        """When nothing changes, changed list should be None."""
+
+        store = Store()
+        trail = Trail()
+        b_id = store.new_var("B")
+
+        # B already set to match entailment
+        set_domain(store, b_id, Domain(((1, 1),)), trail)
+
+        propagator = create_reification_propagator(
+            b_id=b_id,
+            constraint_type="#=",
+            constraint_args=(1, 2),
+            check_entailment=lambda *args: Entailment.TRUE,
+            post_constraint=lambda *args: True,
+            post_negation=lambda *args: True,
+        )
+
+        result = propagator(store, trail, None, None)
+        assert result[0] == "ok"
+        assert result[1] is None  # Nothing changed


### PR DESCRIPTION
## Summary
- Implements reification and implication propagators for CLP(FD) constraints
- Enables B #<==> C (equivalence), B #==> C (forward implication), and B #<== C (backward implication)
- Provides bidirectional propagation between Boolean variables and constraint satisfaction states

## Implementation Details
This PR adds the core reification infrastructure for Stage 5.5 of the CLP(FD) implementation:

### Key Components
- **`create_reification_propagator()`**: Factory function for B #<==> C equivalence
  - Bidirectional propagation: constraint entailment sets Boolean, Boolean value posts constraint
  - Loop prevention via `posted_true` and `posted_false` flags
  - Full integration with entailment detection system

- **`create_implication_propagator()`**: Factory function for directional implications
  - Forward mode (B #==> C): B=1 implies C must hold
  - Backward mode (B #<== C): C holding implies B=1
  - Weaker than equivalence - allows partial constraint relationships

### Design Decisions
- Factory pattern for propagator creation allows flexible constraint type handling
- Closure-based state management for loop prevention flags
- Follows established propagator signature: `(store, trail, engine, cause) -> ('ok'|'fail', changed_vars|None)`
- Leverages existing Boolean domain utilities from `prolog.clpfd.boolean`

## Testing
- 23 comprehensive unit tests covering:
  - Factory function behavior
  - Bidirectional propagation correctness
  - Loop prevention mechanisms
  - Edge cases (bound variables, incompatible domains, failure propagation)
  - Change tracking for incremental propagation

## Test Results
```
All 23 tests in test_clpfd_reif.py passing
Full test suite: 6405 tests passed, no regressions
```

## Files Changed
- `prolog/clpfd/props/reif.py` - New reification propagator implementation
- `prolog/tests/unit/test_clpfd_reif.py` - Comprehensive test suite

Closes #149