### PR TITLE
REPL improvements + Runtime DB: consult(user), formatting; dynamic/1, assert*/retract/retractall/abolish; docs + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ Moves = [move(left,right),move(left,middle),move(right,middle),
  .
 ```
 
+Interactive consult:
+
+```text
+?- consult(user).
+|: parent(tom, bob).
+|: parent(bob, ann).
+|: grandparent(X, Z) :- parent(X, Y), parent(Y, Z).
+|: .
+true.
+?- listing(parent/2).
+parent(tom, bob).
+parent(bob, ann).
+```
+
 ### Command‑line
 
 Run a goal without entering the REPL:

--- a/mkdocs/docs/getting-started/repl.md
+++ b/mkdocs/docs/getting-started/repl.md
@@ -89,11 +89,22 @@ Tips:
 
 ## Loading code
 
-Use `consult('path/to/file.pl').`
+Use `consult('path/to/file.pl').` to load a source file, or `consult(user).` to type clauses interactively.
 
 ```text
 ?- consult('prolog/lib/lists.pl').
 Loaded: prolog/lib/lists.pl
+true.
+```
+
+Interactive input:
+
+```text
+?- consult(user).
+|: parent(tom, bob).
+|: parent(bob, ann).
+|: grandparent(X, Z) :- parent(X, Y), parent(Y, Z).
+|: .
 true.
 ```
 

--- a/mkdocs/docs/guides/repl-tips.md
+++ b/mkdocs/docs/guides/repl-tips.md
@@ -40,13 +40,25 @@ X = 3
 
 The REPL prints `.` after the last solution to indicate completion.
 
-## Loading files
+## Loading files and interactive input
 
-Use `consult('path/to/file.pl').` (quoted string):
+Use `consult('path/to/file.pl').` (quoted string) to load a file, or `consult(user).` to type clauses inline:
 
 ```text
 ?- consult('prolog/lib/lists.pl').
 Loaded: prolog/lib/lists.pl
+true.
+```
+
+Interactive session:
+
+```text
+?- consult(user).
+|: edge(a, b).
+|: edge(b, c).
+|: path(X, Z) :- edge(X, Z).
+|: path(X, Z) :- edge(X, Y), path(Y, Z).
+|: .
 true.
 ```
 
@@ -88,4 +100,3 @@ Metrics add small overhead; leave off unless needed.
 ## Exiting
 
 - `quit`, `exit`, or `halt`, or press Ctrl‑D
-

--- a/mkdocs/docs/reference/repl-commands.md
+++ b/mkdocs/docs/reference/repl-commands.md
@@ -13,6 +13,8 @@ Commands are entered at the `?-` prompt without a trailing period, unless noted.
 
 - `consult('path/to/file.pl').` — load a Prolog source file (note the trailing period and quoted path)
   - On success, the completer refreshes with new predicates
+- `consult(user).` — enter interactive clause input mode; type clauses and finish with Ctrl‑D (EOF) or a single `.` line
+  - Clauses are appended to the current program; tracing and spypoints persist
 
 ## Tracing
 
@@ -68,4 +70,3 @@ true.
 Tracing enabled (pretty format to stdout)
 true.
 ```
-

--- a/mkdocs/docs/reference/repl-commands.md
+++ b/mkdocs/docs/reference/repl-commands.md
@@ -16,6 +16,15 @@ Commands are entered at the `?-` prompt without a trailing period, unless noted.
 - `consult(user).` — enter interactive clause input mode; type clauses and finish with Ctrl‑D (EOF) or a single `.` line
   - Clauses are appended to the current program; tracing and spypoints persist
 
+### Runtime database (interactive)
+
+See also: [Runtime Database Predicates](./runtime-db.md)
+
+- `dynamic(Name/Arity)` or `dynamic([PI...])` or `dynamic((PI1,PI2))` — declare dynamic
+- `assertz(Clause)` | `asserta(Clause)` — add clause to a dynamic predicate
+- `retract(Clause)` — remove one matching clause (pattern unifies; variables bind)
+- `abolish(Name/Arity)` or list/conjunction forms — remove all clauses for predicate(s)
+
 ## Tracing
 
 - `trace on` — enable tracing (pretty format to stdout)

--- a/mkdocs/docs/reference/runtime-db.md
+++ b/mkdocs/docs/reference/runtime-db.md
@@ -1,0 +1,102 @@
+# Runtime Database Predicates
+
+PyLog supports a small set of runtime database predicates for adding,
+removing, and declaring predicates during a REPL session.
+
+These are intended for interactive use and simple tooling. They are not yet a
+complete replacement for advanced database features in full Prolog systems.
+
+## Predicates
+
+- `dynamic(+PI)`
+- `assertz(+Clause)`
+- `asserta(+Clause)`
+- `retract(+Clause)`
+- `abolish(+PI)`
+
+Where `PI` is a predicate indicator `name/arity` (e.g., `parent/2`).
+
+### dynamic/1
+
+Declare one or more predicate indicators as dynamic (i.e., allowed to be
+modified at runtime).
+
+Forms accepted:
+
+- Single: `dynamic(parent/2)`
+- List: `dynamic([edge/2, path/2])`
+- Comma‑conjunction: `dynamic((edge/2, path/2))`
+
+A predicate must be declared dynamic before it can be modified with
+`assertz/1`, `asserta/1`, `retract/1`, or `abolish/1`.
+
+### assertz/1 and asserta/1
+
+Add a clause to a dynamic predicate.
+
+- `assertz(+Clause)` appends to the end of the predicate’s clause list.
+- `asserta(+Clause)` inserts at the beginning.
+
+Examples:
+
+```prolog
+?- dynamic(parent/2).
+true.
+
+?- assertz(parent(tom, bob)).
+true.
+
+?- asserta((grandparent(X, Z) :- parent(X, Y), parent(Y, Z))).
+true.
+```
+
+`Clause` can be a fact (e.g., `p(1).`) or a rule written as `Head :- Body`.
+
+### retract/1
+
+Remove a single clause matching the given pattern from a dynamic predicate.
+
+- Succeeds once per call, removing the first matching clause.
+- Matches by unification (variables in the pattern are bound on success).
+- Effects persist across backtracking (i.e., removed clauses stay removed).
+
+Examples:
+
+```prolog
+?- dynamic(p/1), assertz(p(1)), assertz(p(2)).
+true.
+
+?- retract(p(X)).
+X = 1.
+
+?- p(1).
+false.
+
+?- p(2).
+true.
+```
+
+Call `retract/1` again to remove the next matching clause.
+
+### abolish/1
+
+Remove all clauses of a dynamic predicate.
+
+Forms accepted:
+
+- Single: `abolish(parent/2)`
+- List: `abolish([edge/2, path/2])`
+- Comma‑conjunction: `abolish((edge/2, path/2))`
+
+## Notes and limitations
+
+- A predicate must be declared with `dynamic/1` before it can be changed at runtime.
+- `retract/1` currently removes one clause per call. Invoke it repeatedly to remove multiple clauses.
+- Updates preserve the engine’s indexing mode internally.
+- These predicates are designed for the REPL and small scripts; they are not a full module system.
+
+## See also
+
+- REPL: [Loading code and interactive input](../getting-started/repl.md#loading-code)
+- REPL commands: [Reference](./repl-commands.md)
+

--- a/prolog/tests/unit/test_dynamic_db.py
+++ b/prolog/tests/unit/test_dynamic_db.py
@@ -1,0 +1,137 @@
+"""Tests for dynamic database builtins: dynamic/1, assertz/1, asserta/1, retract/1, abolish/1.
+
+Covers single indicator form and list form for dynamic/1.
+"""
+
+from prolog.ast.terms import Atom, Int, Struct, List as PrologList, Var
+from prolog.ast.clauses import Program
+from prolog.engine.engine import Engine
+
+
+def pi(name: str, arity: int) -> Struct:
+    """Helper to build Name/Arity predicate indicator term."""
+    return Struct("/", (Atom(name), Int(arity)))
+
+
+def plist(items):
+    """Helper to build a proper Prolog list from Python items."""
+    result = Atom("[]")
+    for it in reversed(items):
+        result = PrologList((it,), result)
+    return result
+
+
+class TestDynamicSingle:
+    def test_dynamic_then_assert_and_query(self):
+        engine = Engine(Program(()))
+
+        # Declare dynamic predicate p/1
+        ok = engine._execute_builtin(Struct("dynamic", (pi("p", 1),)))
+        assert ok is True
+
+        # Assert a fact p(1) and query it
+        assert engine._execute_builtin(Struct("assertz", (Struct("p", (Int(1),)),)))
+        sols = engine.run([Struct("p", (Int(1),))])
+        assert len(sols) == 1
+
+    def test_assert_fails_without_dynamic(self):
+        engine = Engine(Program(()))
+        # No dynamic declaration for q/2
+        ok = engine._execute_builtin(
+            Struct("assertz", (Struct("q", (Int(1), Int(2))),))
+        )
+        assert ok is False
+
+    def test_retract_and_abolish(self):
+        engine = Engine(Program(()))
+        # dynamic r/1
+        assert engine._execute_builtin(Struct("dynamic", (pi("r", 1),)))
+        # add two facts r(1), r(2)
+        assert engine._execute_builtin(Struct("assertz", (Struct("r", (Int(1),)),)))
+        assert engine._execute_builtin(Struct("assertz", (Struct("r", (Int(2),)),)))
+
+        # retract first matching clause r(1)
+        assert engine._execute_builtin(Struct("retract", (Struct("r", (Int(1),)),)))
+        sols = engine.run([Struct("r", (Int(1),))])
+        assert len(sols) == 0
+        sols = engine.run([Struct("r", (Int(2),))])
+        assert len(sols) == 1
+
+        # abolish all r/1
+        assert engine._execute_builtin(Struct("abolish", (pi("r", 1),)))
+        sols = engine.run([Struct("r", (Int(2),))])
+        assert len(sols) == 0
+
+
+class TestDynamicListForm:
+    def test_dynamic_list_form_declares_multiple(self):
+        engine = Engine(Program(()))
+
+        # dynamic([a/0, b/1])
+        lst = plist([pi("a", 0), pi("b", 1)])
+        assert engine._execute_builtin(Struct("dynamic", (lst,)))
+
+        # assertz(a).
+        assert engine._execute_builtin(Struct("assertz", (Atom("a"),)))
+        # assertz(b(42)).
+        assert engine._execute_builtin(Struct("assertz", (Struct("b", (Int(42),)),)))
+
+        # queries succeed
+        assert len(engine.run([Atom("a")])) == 1
+        assert len(engine.run([Struct("b", (Int(42),))])) == 1
+
+    def test_dynamic_list_form_invalid_element_fails(self):
+        engine = Engine(Program(()))
+        # dynamic([not_a_pi]). Should fail
+        lst = plist([Atom("foo")])
+        assert engine._execute_builtin(Struct("dynamic", (lst,))) is False
+
+    def test_dynamic_comma_conjunction_form(self):
+        engine = Engine(Program(()))
+        # dynamic((a/0, b/1))
+        conj = Struct(",", (pi("a", 0), pi("b", 1)))
+        assert engine._execute_builtin(Struct("dynamic", (conj,)))
+        # Asserts now allowed
+        assert engine._execute_builtin(Struct("assertz", (Atom("a"),)))
+        assert engine._execute_builtin(Struct("assertz", (Struct("b", (Int(5),)),)))
+        assert len(engine.run([Atom("a")])) == 1
+        assert len(engine.run([Struct("b", (Int(5),))])) == 1
+
+    def test_abolish_list_and_comma_forms(self):
+        engine = Engine(Program(()))
+        # Declare and assert
+        assert engine._execute_builtin(
+            Struct("dynamic", (plist([pi("a", 0), pi("b", 1)]),))
+        )
+        assert engine._execute_builtin(Struct("assertz", (Atom("a"),)))
+        assert engine._execute_builtin(Struct("assertz", (Struct("b", (Int(7),)),)))
+        assert len(engine.run([Atom("a")])) == 1
+        assert len(engine.run([Struct("b", (Int(7),))])) == 1
+
+        # Abolish list
+        assert engine._execute_builtin(Struct("abolish", (plist([pi("a", 0)]),)))
+        assert len(engine.run([Atom("a")])) == 0
+        assert len(engine.run([Struct("b", (Int(7),))])) == 1
+
+        # Abolish via comma-conjunction: remove remaining b/1
+        conj = Struct(",", (pi("a", 0), pi("b", 1)))
+        assert engine._execute_builtin(Struct("abolish", (conj,)))
+        assert len(engine.run([Struct("b", (Int(7),))])) == 0
+
+
+class TestRetractUnification:
+    def test_retract_binds_variables(self):
+        engine = Engine(Program(()))
+        assert engine._execute_builtin(Struct("dynamic", (pi("p", 1),)))
+        assert engine._execute_builtin(Struct("assertz", (Struct("p", (Int(1),)),)))
+        assert engine._execute_builtin(Struct("assertz", (Struct("p", (Int(2),)),)))
+
+        # Query retract(p(X)) should bind X to first matching (1)
+        x = Var(engine.store.new_var("X"), "X")
+        engine._query_vars = [(x.id, "X")]
+        sols = engine.run([Struct("retract", (Struct("p", (x,)),))])
+        assert len(sols) == 1
+        assert sols[0]["X"] == Int(1)
+        # Ensure p(1) was removed, p(2) remains
+        assert len(engine.run([Struct("p", (Int(1),))])) == 0
+        assert len(engine.run([Struct("p", (Int(2),))])) == 1


### PR DESCRIPTION
This PR enhances the REPL experience and adds a small runtime database feature set.

Highlights

REPL quality of life
- consult(user): interactive clause input (Ctrl‑D to finish); keeps tracing/spypoints intact
- Matrix pretty‑print for rectangular nested lists (e.g., Sudoku grids) with indentation
- Tab now accepts inline history suggestions; still cycles completions when no suggestion
- Robust query completeness: strip % line and /* */ block comments before checking the trailing period

Runtime database built-ins
- dynamic/1
  - Accepts single PI (p/1), list form (dynamic([p/1,q/2])), and comma‑conjunction (dynamic((p/1,q/2)))
- assertz/1, asserta/1
  - Append/prepend facts or rules; require dynamic(Name/Arity) prior to modifications
- retract/1
  - Unification‑based removal (binds variables in the query on success), one clause per call
- retractall/1
  - Remove all matching clauses in one call; does not bind variables in the query
- abolish/1
  - Remove all clauses for dynamic predicates; supports list and comma‑conjunction forms
- Indexing preserved across updates (program rebuilt with IndexedProgram when enabled)

Docs
- New page: Reference → Runtime database
- REPL commands reference updated to include runtime DB predicates and link to the new page
- README REPL section includes consult(user) example

Tests
- New unit tests for dynamic list/comma forms, abolish list/comma forms, retract variable binding, retractall semantics
- All functional tests pass locally; one perf benchmark assertion can be noisy on local hardware but CI generally stabilizes

Notes / scope
- retract/1 removes the first matching clause per call; repeat to remove more
- retractall/1 unifies but does not bind variables and always succeeds
- Not a full module or persistent DB; designed for interactive REPL workflows
