### PR TITLE
Phase 1: Extract Pure Utilities to engine/utils/

### DIFF
--- a/prolog/engine/utils/__init__.py
+++ b/prolog/engine/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the Prolog engine."""

--- a/prolog/engine/utils/arithmetic.py
+++ b/prolog/engine/utils/arithmetic.py
@@ -1,0 +1,145 @@
+"""Arithmetic evaluation utilities extracted from engine.py."""
+
+from typing import Union
+from prolog.ast.terms import Term, Atom, Int, Float, Var, Struct
+
+
+def eval_int(store, t: Term) -> int:
+    """Evaluate a term as an integer.
+
+    Args:
+        store: The unification store
+        t: The term to evaluate.
+
+    Returns:
+        The integer value.
+
+    Raises:
+        ValueError: If the term is not an integer.
+    """
+    if isinstance(t, Int):
+        return t.value
+    if isinstance(t, Var):
+        r = store.deref(t.id)
+        if r[0] == "BOUND":
+            _, _, b = r
+            return eval_int(store, b)
+    raise ValueError("non-integer")
+
+
+def eval_arithmetic(store, term: Term) -> Union[int, float]:
+    """Evaluate an arithmetic expression iteratively.
+
+    Args:
+        store: The unification store
+        term: The term to evaluate.
+
+    Returns:
+        The numeric result (int or float).
+
+    Raises:
+        ValueError: If evaluation fails.
+    """
+    # Stack-based evaluation to avoid recursion
+    # Each entry is either ('eval', term) or ('apply', op, values)
+    eval_stack = [("eval", term)]
+    value_stack = []
+
+    while eval_stack:
+        action, data = eval_stack.pop()
+
+        if action == "eval":
+            t = data
+
+            # Dereference if variable
+            if isinstance(t, Var):
+                result = store.deref(t.id)
+                if result[0] == "BOUND":
+                    _, _, bound_term = result
+                    t = bound_term
+                else:
+                    raise ValueError("Unbound variable in arithmetic")
+
+            if isinstance(t, Int):
+                value_stack.append(t.value)
+            elif isinstance(t, Float):
+                value_stack.append(t.value)
+            elif isinstance(t, Struct):
+                if (
+                    t.functor in ["+", "-", "*", "//", "/", "mod", "max", "min", "**"]
+                    and len(t.args) == 2
+                ):
+                    # Binary operator: evaluate args then apply
+                    eval_stack.append(("apply", Atom(t.functor)))
+                    # Push args in reverse order for correct evaluation
+                    eval_stack.append(("eval", t.args[1]))
+                    eval_stack.append(("eval", t.args[0]))
+                elif t.functor == "-" and len(t.args) == 1:
+                    # Unary minus
+                    eval_stack.append(("apply_unary", Atom("-")))
+                    eval_stack.append(("eval", t.args[0]))
+                else:
+                    raise ValueError(
+                        f"Unknown arithmetic operator: {t.functor}/{len(t.args)}"
+                    )
+            else:
+                raise ValueError(f"Cannot evaluate arithmetic: {t}")
+
+        elif action == "apply":
+            op_atom = data
+            # Extract operator name from Atom
+            op = op_atom.name if isinstance(op_atom, Atom) else str(op_atom)
+            if len(value_stack) < 2:
+                raise ValueError(f"Not enough values for operator {op}")
+
+            right = value_stack.pop()
+            left = value_stack.pop()
+
+            if op == "+":
+                value_stack.append(left + right)
+            elif op == "-":
+                value_stack.append(left - right)
+            elif op == "*":
+                value_stack.append(left * right)
+            elif op == "//":
+                if right == 0:
+                    raise ValueError("Division by zero")
+                value_stack.append(left // right)
+            elif op == "/":
+                if right == 0:
+                    raise ValueError("Division by zero")
+                value_stack.append(left / right)  # Float division
+            elif op == "mod":
+                if right == 0:
+                    raise ValueError("Modulo by zero")
+                value_stack.append(left % right)
+            elif op == "max":
+                value_stack.append(max(left, right))
+            elif op == "min":
+                value_stack.append(min(left, right))
+            elif op == "**":
+                try:
+                    result = left**right
+                    value_stack.append(result)
+                except (OverflowError, ValueError):
+                    raise ValueError("Power operation overflow or invalid")
+
+        elif action == "apply_unary":
+            op_atom = data
+            # Extract operator name from Atom
+            op = op_atom.name if isinstance(op_atom, Atom) else str(op_atom)
+            if not value_stack:
+                raise ValueError("Not enough values for unary operator")
+            value = value_stack.pop()
+
+            if op == "-":
+                value_stack.append(-value)
+            else:
+                raise ValueError(f"Unknown unary operator: {op}")
+
+    if len(value_stack) != 1:
+        raise ValueError(
+            f"Arithmetic evaluation error: expected 1 value, got {len(value_stack)}"
+        )
+
+    return value_stack[0]

--- a/prolog/engine/utils/copy.py
+++ b/prolog/engine/utils/copy.py
@@ -1,0 +1,45 @@
+"""Term copying utilities extracted from engine.py."""
+
+from typing import Dict, List
+from prolog.ast.terms import Term, Atom, Int, Float, Var, Struct, List as PrologList
+
+
+def copy_term_with_fresh_vars(store, term: Term) -> Term:
+    """Create a copy of a term with fresh variables."""
+    var_mapping = {}
+    return copy_term_recursive(term, var_mapping, store)
+
+
+def copy_term_recursive(term: Term, var_mapping: Dict[int, int], target_store) -> Term:
+    """Recursively copy a term, mapping old var IDs to new ones."""
+    if isinstance(term, Var):
+        if term.id not in var_mapping:
+            var_mapping[term.id] = target_store.new_var(term.hint)
+        return Var(var_mapping[term.id], term.hint)
+    elif isinstance(term, (Atom, Int, Float)):
+        return term
+    elif isinstance(term, Struct):
+        new_args = tuple(
+            copy_term_recursive(arg, var_mapping, target_store) for arg in term.args
+        )
+        return Struct(term.functor, new_args)
+    elif isinstance(term, PrologList):
+        new_items = tuple(
+            copy_term_recursive(item, var_mapping, target_store) for item in term.items
+        )
+        new_tail = copy_term_recursive(term.tail, var_mapping, target_store)
+        return PrologList(new_items, new_tail)
+    return term
+
+
+def build_prolog_list(items: List[Term]) -> Term:
+    """Build a Prolog list term from a list of items."""
+    if not items:
+        return Atom("[]")
+
+    # Build list from right to left
+    result = Atom("[]")
+    for item in reversed(items):
+        result = PrologList((item,), tail=result)
+
+    return result

--- a/prolog/engine/utils/terms.py
+++ b/prolog/engine/utils/terms.py
@@ -1,0 +1,128 @@
+"""Term utility functions extracted from engine.py.
+
+This module contains pure utility functions for term manipulation that don't
+depend on engine state beyond the store and variable name mappings.
+"""
+
+from typing import Any, Dict
+from prolog.ast.terms import Term, Atom, Int, Float, Var, Struct, List as PrologList
+
+
+def reify_var(store, qname_by_id: Dict[int, str], varid: int) -> Any:
+    """Follow bindings to get the value of a variable.
+
+    Args:
+        store: The unification store
+        qname_by_id: Query variable name mapping
+        varid: The variable ID to reify.
+
+    Returns:
+        The ground term or a variable representation.
+    """
+    # Dereference to find what it's bound to
+    result = store.deref(varid)
+
+    if result[0] == "UNBOUND":
+        # Unbound variable - return a representation
+        _, ref = result
+        # Fast lookup for query var name, default to _<id>
+        hint = qname_by_id.get(ref, f"_{ref}")
+        return Var(ref, hint)
+
+    elif result[0] == "BOUND":
+        # Bound to a term - reify iteratively
+        _, ref, term = result
+        return reify_term(store, qname_by_id, term)
+
+    else:
+        raise ValueError(f"Unknown cell tag: {result[0]}")
+
+
+def reify_term(store, qname_by_id: Dict[int, str], term: Term) -> Any:
+    """Reify a term, following variable bindings (iterative).
+
+    Reified lists are always flattened: nested PrologList structures
+    where the tail is also a PrologList will be combined into a single
+    PrologList. Improper lists (with non-list tails) retain their tail.
+
+    Args:
+        store: The unification store
+        qname_by_id: Query variable name mapping
+        term: The term to reify.
+
+    Returns:
+        The ground term with variables reified.
+    """
+    # Use iterative approach to avoid stack overflow
+    stack = [term]
+    visited = set()
+    all_terms = []
+
+    # First pass: collect all terms in dependency order
+    while stack:
+        current = stack.pop()
+        term_id = id(current)
+
+        if term_id in visited:
+            continue
+        visited.add(term_id)
+        all_terms.append(current)
+
+        if isinstance(current, Var):
+            # Will need to check binding
+            result = store.deref(current.id)
+            if result[0] == "BOUND":
+                _, _, bound_term = result
+                stack.append(bound_term)
+        elif isinstance(current, Struct):
+            for arg in reversed(current.args):
+                stack.append(arg)
+        elif isinstance(current, PrologList):
+            stack.append(current.tail)
+            for item in reversed(current.items):
+                stack.append(item)
+
+    # Second pass: reify bottom-up
+    reified = {}
+    for current in reversed(all_terms):
+        term_id = id(current)
+
+        if isinstance(current, Var):
+            result = store.deref(current.id)
+            if result[0] == "UNBOUND":
+                # Unbound variable - return a representation
+                _, ref = result
+                # Fast lookup for query var name
+                hint = qname_by_id.get(ref, f"_{ref}")
+                reified[term_id] = Var(ref, hint)
+            elif result[0] == "BOUND":
+                # Use reified version of bound term
+                _, _, bound_term = result
+                reified[term_id] = reified.get(id(bound_term), bound_term)
+            else:
+                raise ValueError(f"Unknown cell tag: {result[0]}")
+
+        elif isinstance(current, (Atom, Int, Float)):
+            reified[term_id] = current
+
+        elif isinstance(current, Struct):
+            reified_args = tuple(reified.get(id(arg), arg) for arg in current.args)
+            reified[term_id] = Struct(current.functor, reified_args)
+
+        elif isinstance(current, PrologList):
+            reified_items = list(reified.get(id(item), item) for item in current.items)
+            reified_tail = reified.get(id(current.tail), current.tail)
+
+            # Flatten if tail is also a PrologList
+            if isinstance(reified_tail, PrologList):
+                # Combine items from current list with items from tail list
+                all_items = reified_items + list(reified_tail.items)
+                final_tail = reified_tail.tail
+                reified[term_id] = PrologList(tuple(all_items), tail=final_tail)
+            else:
+                reified[term_id] = PrologList(tuple(reified_items), tail=reified_tail)
+        else:
+            # Unknown term type
+            reified[term_id] = current
+
+    return reified.get(id(term), term)


### PR DESCRIPTION
## Summary

Extract pure utility functions from the monolithic `engine.py` into modular utility files under `prolog/engine/utils/`. This is Phase 1 of the engine refactoring plan from issue #243.

## Changes

**New Files Created:**
- `prolog/engine/utils/terms.py` - Term manipulation utilities (`reify_var`, `reify_term`)
- `prolog/engine/utils/copy.py` - Term copying utilities (`copy_term_with_fresh_vars`, `copy_term_recursive`, `build_prolog_list`)
- `prolog/engine/utils/arithmetic.py` - Arithmetic evaluation utilities (`eval_int`, `eval_arithmetic`)

**Modified:**
- `prolog/engine/engine.py` - Updated imports and delegated method calls to utility functions

## Testing

- ✅ All existing tests pass
- ✅ No functionality changes - pure refactoring
- ✅ Utilities maintain identical behavior through delegation

## Benefits

- Improved code organization and modularity
- Easier testing of individual utility functions
- Reduced complexity in main engine file
- Foundation for further refactoring phases

Closes #244