### PR TITLE
Implement type check builtins: var/1, nonvar/1, atom/1, integer/1, number/1

### DIFF
--- a/prolog/tests/unit/test_wam_builtins_type.py
+++ b/prolog/tests/unit/test_wam_builtins_type.py
@@ -1,0 +1,355 @@
+"""Tests for WAM type checking builtins."""
+
+
+from prolog.wam.builtins import WAM_BUILTINS
+from prolog.wam.heap import new_con, new_ref, new_str
+from prolog.wam.instructions import OP_CALL_BUILTIN
+from prolog.wam.machine import Machine
+
+
+class TestVarBuiltin:
+    """Test var/1 builtin."""
+
+    def test_var_with_unbound_variable(self):
+        """var(X) succeeds when X is unbound."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:var/1"](machine)
+        assert result is True
+
+    def test_var_with_integer_fails(self):
+        """var(5) fails."""
+        machine = Machine()
+        int_addr = new_con(machine, 5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:var/1"](machine)
+        assert result is False
+
+    def test_var_with_atom_fails(self):
+        """var(foo) fails."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        result = WAM_BUILTINS["system:var/1"](machine)
+        assert result is False
+
+    def test_var_with_structure_fails(self):
+        """var(f(a)) fails."""
+        machine = Machine()
+        f_addr = new_str(machine, "f", 1)
+        a_addr = new_con(machine, "a")
+        machine.heap.append((0, a_addr))  # Add argument
+
+        machine.X = [f_addr]
+
+        result = WAM_BUILTINS["system:var/1"](machine)
+        assert result is False
+
+    def test_var_with_bound_variable_fails(self):
+        """var(X) fails when X is bound."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        val_addr = new_con(machine, 42)
+
+        # Bind X to 42
+        machine.heap[x_addr] = (0, val_addr)  # TAG_REF
+
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:var/1"](machine)
+        assert result is False
+
+
+class TestNonvarBuiltin:
+    """Test nonvar/1 builtin."""
+
+    def test_nonvar_with_integer_succeeds(self):
+        """nonvar(5) succeeds."""
+        machine = Machine()
+        int_addr = new_con(machine, 5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:nonvar/1"](machine)
+        assert result is True
+
+    def test_nonvar_with_atom_succeeds(self):
+        """nonvar(foo) succeeds."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        result = WAM_BUILTINS["system:nonvar/1"](machine)
+        assert result is True
+
+    def test_nonvar_with_unbound_variable_fails(self):
+        """nonvar(X) fails when X is unbound."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:nonvar/1"](machine)
+        assert result is False
+
+    def test_nonvar_with_bound_variable_succeeds(self):
+        """nonvar(X) succeeds when X is bound."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        val_addr = new_con(machine, 42)
+
+        # Bind X to 42
+        machine.heap[x_addr] = (0, val_addr)  # TAG_REF
+
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:nonvar/1"](machine)
+        assert result is True
+
+
+class TestAtomBuiltin:
+    """Test atom/1 builtin."""
+
+    def test_atom_with_atom_succeeds(self):
+        """atom(foo) succeeds."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is True
+
+    def test_atom_with_empty_list_succeeds(self):
+        """atom([]) succeeds (empty list is atom)."""
+        machine = Machine()
+        nil_addr = new_con(machine, "[]")
+        machine.X = [nil_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is True
+
+    def test_atom_with_integer_fails(self):
+        """atom(5) fails."""
+        machine = Machine()
+        int_addr = new_con(machine, 5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is False
+
+    def test_atom_with_float_fails(self):
+        """atom(5.0) fails."""
+        machine = Machine()
+        float_addr = new_con(machine, 5.0)
+        machine.X = [float_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is False
+
+    def test_atom_with_variable_fails(self):
+        """atom(X) fails."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is False
+
+    def test_atom_with_structure_fails(self):
+        """atom(f(a)) fails."""
+        machine = Machine()
+        f_addr = new_str(machine, "f", 1)
+        a_addr = new_con(machine, "a")
+        machine.heap.append((0, a_addr))
+
+        machine.X = [f_addr]
+
+        result = WAM_BUILTINS["system:atom/1"](machine)
+        assert result is False
+
+
+class TestIntegerBuiltin:
+    """Test integer/1 builtin."""
+
+    def test_integer_with_positive_integer_succeeds(self):
+        """integer(5) succeeds."""
+        machine = Machine()
+        int_addr = new_con(machine, 5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is True
+
+    def test_integer_with_negative_integer_succeeds(self):
+        """integer(-5) succeeds."""
+        machine = Machine()
+        int_addr = new_con(machine, -5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is True
+
+    def test_integer_with_zero_succeeds(self):
+        """integer(0) succeeds."""
+        machine = Machine()
+        int_addr = new_con(machine, 0)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is True
+
+    def test_integer_with_float_fails(self):
+        """integer(5.0) fails."""
+        machine = Machine()
+        float_addr = new_con(machine, 5.0)
+        machine.X = [float_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is False
+
+    def test_integer_with_atom_fails(self):
+        """integer(foo) fails."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is False
+
+    def test_integer_with_variable_fails(self):
+        """integer(X) fails."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:integer/1"](machine)
+        assert result is False
+
+
+class TestNumberBuiltin:
+    """Test number/1 builtin."""
+
+    def test_number_with_integer_succeeds(self):
+        """number(5) succeeds."""
+        machine = Machine()
+        int_addr = new_con(machine, 5)
+        machine.X = [int_addr]
+
+        result = WAM_BUILTINS["system:number/1"](machine)
+        assert result is True
+
+    def test_number_with_float_succeeds(self):
+        """number(5.0) succeeds."""
+        machine = Machine()
+        float_addr = new_con(machine, 5.0)
+        machine.X = [float_addr]
+
+        result = WAM_BUILTINS["system:number/1"](machine)
+        assert result is True
+
+    def test_number_with_negative_float_succeeds(self):
+        """number(-3.14) succeeds."""
+        machine = Machine()
+        float_addr = new_con(machine, -3.14)
+        machine.X = [float_addr]
+
+        result = WAM_BUILTINS["system:number/1"](machine)
+        assert result is True
+
+    def test_number_with_atom_fails(self):
+        """number(foo) fails."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        result = WAM_BUILTINS["system:number/1"](machine)
+        assert result is False
+
+    def test_number_with_variable_fails(self):
+        """number(X) fails."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        result = WAM_BUILTINS["system:number/1"](machine)
+        assert result is False
+
+
+class TestInstructionIntegration:
+    """Test integration with OP_CALL_BUILTIN instruction."""
+
+    def test_var_via_instruction(self):
+        """Test var/1 via OP_CALL_BUILTIN instruction."""
+        machine = Machine()
+        x_addr = new_ref(machine)
+        machine.X = [x_addr]
+
+        machine.code = [
+            (OP_CALL_BUILTIN, "system:var/1"),
+        ]
+        machine.P = 0
+
+        # Execute instruction
+        result = machine.step()
+
+        assert result is True
+        assert machine.P == 1  # Advanced to next instruction
+
+    def test_atom_via_instruction_succeeds(self):
+        """Test atom/1 via OP_CALL_BUILTIN instruction (success)."""
+        machine = Machine()
+        atom_addr = new_con(machine, "foo")
+        machine.X = [atom_addr]
+
+        machine.code = [
+            (OP_CALL_BUILTIN, "system:atom/1"),
+        ]
+        machine.P = 0
+
+        result = machine.step()
+
+        assert result is True
+        assert machine.P == 1
+
+    def test_atom_via_instruction_fails(self):
+        """Test atom/1 via OP_CALL_BUILTIN instruction (failure)."""
+        machine = Machine()
+        int_addr = new_con(machine, 42)
+        machine.X = [int_addr]
+
+        machine.code = [
+            (OP_CALL_BUILTIN, "system:atom/1"),
+        ]
+        machine.P = 0
+
+        # Execute instruction
+        machine.step()
+
+        # Should have halted on failure
+        assert machine.halted
+
+
+class TestBuiltinRegistration:
+    """Test that type builtins are registered on module import."""
+
+    def test_var_registered(self):
+        """var/1 is registered in WAM_BUILTINS."""
+        assert "system:var/1" in WAM_BUILTINS
+
+    def test_nonvar_registered(self):
+        """nonvar/1 is registered in WAM_BUILTINS."""
+        assert "system:nonvar/1" in WAM_BUILTINS
+
+    def test_atom_registered(self):
+        """atom/1 is registered in WAM_BUILTINS."""
+        assert "system:atom/1" in WAM_BUILTINS
+
+    def test_integer_registered(self):
+        """integer/1 is registered in WAM_BUILTINS."""
+        assert "system:integer/1" in WAM_BUILTINS
+
+    def test_number_registered(self):
+        """number/1 is registered in WAM_BUILTINS."""
+        assert "system:number/1" in WAM_BUILTINS

--- a/prolog/wam/builtins.py
+++ b/prolog/wam/builtins.py
@@ -23,6 +23,7 @@ Example builtin handler:
 
 from __future__ import annotations
 
+from prolog.wam.builtins_type import register_type_builtins
 from prolog.wam.errors import python_exception_to_prolog
 
 __all__ = [
@@ -35,6 +36,9 @@ __all__ = [
 # Builtin registry: maps "module:name/arity" to handler function
 # Handler signature: (machine) -> bool
 WAM_BUILTINS: dict[str, callable] = {}
+
+# Register type checking builtins
+register_type_builtins(WAM_BUILTINS)
 
 
 def register_builtin(symbol: str, handler: callable) -> None:

--- a/prolog/wam/builtins_type.py
+++ b/prolog/wam/builtins_type.py
@@ -1,0 +1,171 @@
+"""WAM type checking builtins.
+
+Implements ISO Prolog type checking predicates:
+- var/1: Check if argument is unbound variable
+- nonvar/1: Check if argument is bound (non-variable)
+- atom/1: Check if argument is an atom
+- integer/1: Check if argument is an integer
+- number/1: Check if argument is a number (integer or float)
+
+All type check builtins are deterministic (no choicepoints) and have no side effects.
+They succeed or fail based on the type of the dereferenced argument.
+"""
+
+from __future__ import annotations
+
+from prolog.wam.heap import TAG_CON, TAG_REF
+from prolog.wam.unify import deref
+
+__all__ = [
+    "builtin_var",
+    "builtin_nonvar",
+    "builtin_atom",
+    "builtin_integer",
+    "builtin_number",
+    "register_type_builtins",
+]
+
+
+def builtin_var(machine) -> bool:
+    """var(X): Succeeds if X is an unbound variable.
+
+    Args:
+        machine: Machine with X[0] containing argument address
+
+    Returns:
+        True if X[0] is unbound variable, False otherwise
+
+    Example:
+        ?- var(X).          % succeeds
+        ?- var(5).          % fails
+        ?- X = Y, var(X).   % fails (X bound to Y)
+    """
+    addr = machine.X[0]
+    dereffed = deref(machine, addr)
+    cell = machine.heap[dereffed]
+
+    # Unbound if REF pointing to itself
+    return cell[0] == TAG_REF and cell[1] == dereffed
+
+
+def builtin_nonvar(machine) -> bool:
+    """nonvar(X): Succeeds if X is not an unbound variable.
+
+    Args:
+        machine: Machine with X[0] containing argument address
+
+    Returns:
+        True if X[0] is bound (not unbound variable), False otherwise
+
+    Example:
+        ?- nonvar(5).       % succeeds
+        ?- nonvar(X).       % fails
+        ?- X = 5, nonvar(X). % succeeds
+    """
+    addr = machine.X[0]
+    dereffed = deref(machine, addr)
+    cell = machine.heap[dereffed]
+
+    # Bound if not a self-referential REF
+    return not (cell[0] == TAG_REF and cell[1] == dereffed)
+
+
+def builtin_atom(machine) -> bool:
+    """atom(X): Succeeds if X is an atom.
+
+    Args:
+        machine: Machine with X[0] containing argument address
+
+    Returns:
+        True if X[0] is an atom, False otherwise
+
+    Example:
+        ?- atom(foo).       % succeeds
+        ?- atom(5).         % fails
+        ?- atom(X).         % fails
+        ?- atom([]).        % succeeds (empty list is atom)
+    """
+    addr = machine.X[0]
+    dereffed = deref(machine, addr)
+    cell = machine.heap[dereffed]
+
+    # Atom if CON with string value
+    if cell[0] != TAG_CON:
+        return False
+
+    value = cell[1]
+    return isinstance(value, str)
+
+
+def builtin_integer(machine) -> bool:
+    """integer(X): Succeeds if X is an integer.
+
+    Args:
+        machine: Machine with X[0] containing argument address
+
+    Returns:
+        True if X[0] is an integer, False otherwise
+
+    Example:
+        ?- integer(5).      % succeeds
+        ?- integer(5.0).    % fails
+        ?- integer(foo).    % fails
+        ?- integer(X).      % fails
+    """
+    addr = machine.X[0]
+    dereffed = deref(machine, addr)
+    cell = machine.heap[dereffed]
+
+    # Integer if CON with int value (not bool, which is also int in Python)
+    if cell[0] != TAG_CON:
+        return False
+
+    value = cell[1]
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def builtin_number(machine) -> bool:
+    """number(X): Succeeds if X is a number (integer or float).
+
+    Args:
+        machine: Machine with X[0] containing argument address
+
+    Returns:
+        True if X[0] is a number, False otherwise
+
+    Example:
+        ?- number(5).       % succeeds
+        ?- number(5.0).     % succeeds
+        ?- number(foo).     % fails
+        ?- number(X).       % fails
+    """
+    addr = machine.X[0]
+    dereffed = deref(machine, addr)
+    cell = machine.heap[dereffed]
+
+    # Number if CON with int or float value
+    if cell[0] != TAG_CON:
+        return False
+
+    value = cell[1]
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def register_type_builtins(registry: dict) -> None:
+    """Register all type checking builtins in the given registry.
+
+    Args:
+        registry: Builtin registry dict to populate
+
+    Registers:
+        - system:var/1
+        - system:nonvar/1
+        - system:atom/1
+        - system:integer/1
+        - system:number/1
+    """
+    registry["system:var/1"] = builtin_var
+    registry["system:nonvar/1"] = builtin_nonvar
+    registry["system:atom/1"] = builtin_atom
+    registry["system:integer/1"] = builtin_integer
+    registry["system:number/1"] = builtin_number


### PR DESCRIPTION
Add five ISO Prolog type checking predicates to WAM builtin registry.

## Implementation

Created `prolog/wam/builtins_type.py` with five builtin handlers:
- `system:var/1`: Check if argument is unbound variable
- `system:nonvar/1`: Check if argument is bound (non-variable)
- `system:atom/1`: Check if argument is an atom
- `system:integer/1`: Check if argument is an integer
- `system:number/1`: Check if argument is a number (integer or float)

All builtins are deterministic (no choicepoints), side-effect-free, and check the dereferenced argument type. Handlers return `bool` and are registered automatically at module import time via `register_type_builtins()`.

## Tests

Created `prolog/tests/unit/test_wam_builtins_type.py` with 34 comprehensive tests:
- Type-specific tests for each builtin with various scenarios
- Integration tests via OP_CALL_BUILTIN instruction
- Registry verification tests confirming all builtins are registered

## Fixes

Fixed `prolog/tests/unit/test_wam_builtins.py`:
- Changed `test_example_var_builtin` to use `test:example_var/1` instead of `system:var/1` to avoid collision with pre-registered builtins
- Updated `test_registry_initially_empty` to `test_registry_can_be_cleared_and_restored` to account for pre-registered builtins

All 699 WAM tests passing.

Resolves #386