### PR TITLE
Arithmetic evaluation engine for WAM

### DIFF
--- a/prolog/tests/unit/test_wam_arithmetic.py
+++ b/prolog/tests/unit/test_wam_arithmetic.py
@@ -1,0 +1,358 @@
+"""Tests for WAM arithmetic evaluation engine."""
+
+import pytest
+
+from prolog.wam.arithmetic import eval_arithmetic
+from prolog.wam.errors import EvaluationError, InstantiationError, TypeError
+from prolog.wam.heap import new_con, new_ref, new_str, note_struct_args
+from prolog.wam.machine import Machine
+
+
+def build_const_binary_op(machine, op: str, left_val, right_val) -> int:
+    """Build binary operation with constant operands.
+
+    Args:
+        machine: Machine instance
+        op: Operator name ("+", "-", etc.)
+        left_val: Left constant value (int/float)
+        right_val: Right constant value (int/float)
+
+    Returns:
+        Address of structure
+    """
+    # Create structure first (STR + functor cells)
+    struct_addr = new_str(machine, op, 2)
+    # Now create argument cells - they'll be at functor+1 and functor+2
+    new_con(machine, left_val)
+    new_con(machine, right_val)
+    return struct_addr
+
+
+def build_binary_op(machine, op: str, left_addr, right_addr) -> int:
+    """Build binary operation with existing operands.
+
+    Args:
+        machine: Machine instance
+        op: Operator name ("+", "-", etc.)
+        left_addr: Left operand address (already on heap)
+        right_addr: Right operand address (already on heap)
+
+    Returns:
+        Address of structure
+    """
+    # Create structure first (STR + functor cells)
+    struct_addr = new_str(machine, op, 2)
+    # Copy the operand cells to argument positions
+    machine.heap.append(machine.heap[left_addr])
+    machine.heap.append(machine.heap[right_addr])
+    return struct_addr
+
+
+def build_const_unary_op(machine, op: str, arg_val) -> int:
+    """Build unary operation with constant operand.
+
+    Args:
+        machine: Machine instance
+        op: Operator name ("-", "+")
+        arg_val: Argument constant value
+
+    Returns:
+        Address of structure
+    """
+    struct_addr = new_str(machine, op, 1)
+    new_con(machine, arg_val)
+    return struct_addr
+
+
+class TestArithmeticConstants:
+    """Test arithmetic evaluation of constants."""
+
+    def test_integer_constant(self):
+        """Evaluate integer constant."""
+        machine = Machine()
+        addr = new_con(machine, 42)
+
+        result = eval_arithmetic(addr, machine)
+
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_negative_integer_constant(self):
+        """Evaluate negative integer constant."""
+        machine = Machine()
+        addr = new_con(machine, -17)
+
+        result = eval_arithmetic(addr, machine)
+
+        assert result == -17
+
+    def test_zero_constant(self):
+        """Evaluate zero."""
+        machine = Machine()
+        addr = new_con(machine, 0)
+
+        result = eval_arithmetic(addr, machine)
+
+        assert result == 0
+
+    def test_float_constant(self):
+        """Evaluate float constant."""
+        machine = Machine()
+        addr = new_con(machine, 3.14)
+
+        result = eval_arithmetic(addr, machine)
+
+        assert result == 3.14
+        assert isinstance(result, float)
+
+
+class TestArithmeticBinaryOperators:
+    """Test binary arithmetic operators."""
+
+    def test_addition(self):
+        """Evaluate 2 + 3 → 5."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "+", 2, 3)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 5
+
+    def test_subtraction(self):
+        """Evaluate 10 - 3 → 7."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "-", 10, 3)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 7
+
+    def test_multiplication(self):
+        """Evaluate 4 * 5 → 20."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "*", 4, 5)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 20
+
+    def test_float_division(self):
+        """Evaluate 7 / 2 → 3.5."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "/", 7, 2)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 3.5
+        assert isinstance(result, float)
+
+    def test_integer_division(self):
+        """Evaluate 7 // 2 → 3."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "//", 7, 2)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 3
+        assert isinstance(result, int)
+
+    def test_integer_division_negative(self):
+        """Evaluate -7 // 2 → -4 (floor division)."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "//", -7, 2)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == -4
+
+    def test_modulo(self):
+        """Evaluate 7 mod 3 → 1."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "mod", 7, 3)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 1
+
+    def test_modulo_negative(self):
+        """Evaluate -7 mod 3 → 2 (Python semantics)."""
+        machine = Machine()
+        struct_addr = build_const_binary_op(machine, "mod", -7, 3)
+        result = eval_arithmetic(struct_addr, machine)
+        assert result == 2
+
+
+class TestArithmeticUnaryOperators:
+    """Test unary arithmetic operators."""
+
+    def test_unary_minus(self):
+        """Evaluate -(5) → -5."""
+        machine = Machine()
+
+        struct_addr = build_const_unary_op(machine, "-", 5)
+
+        result = eval_arithmetic(struct_addr, machine)
+
+        assert result == -5
+
+    def test_unary_minus_negative(self):
+        """Evaluate -(-5) → 5."""
+        machine = Machine()
+
+        struct_addr = build_const_unary_op(machine, "-", -5)
+
+        result = eval_arithmetic(struct_addr, machine)
+
+        assert result == 5
+
+    def test_unary_plus(self):
+        """Evaluate +(5) → 5."""
+        machine = Machine()
+
+        struct_addr = build_const_unary_op(machine, "+", 5)
+
+        result = eval_arithmetic(struct_addr, machine)
+
+        assert result == 5
+
+
+class TestArithmeticNested:
+    """Test nested arithmetic expressions."""
+
+    def test_nested_addition(self):
+        """Evaluate (2 + 3) + 4 → 9."""
+        machine = Machine()
+
+        # Build inner: +(2, 3)
+        inner_addr = new_str(machine, "+", 2)
+        new_con(machine, 2)
+        new_con(machine, 3)
+
+        # Build outer: +(inner, 4) - inner is referenced via REF
+        outer_addr = new_str(machine, "+", 2)
+        note_struct_args(machine, inner_addr)  # Append REF(inner) as arg1
+        new_con(machine, 4)  # Allocate 4 as arg2
+
+        result = eval_arithmetic(outer_addr, machine)
+
+        assert result == 9
+
+    def test_precedence_multiplication_addition(self):
+        """Evaluate 2 + 3 * 4 → 14 (assuming correct structure)."""
+        machine = Machine()
+
+        # Build inner: *(3, 4)
+        mult_addr = new_str(machine, "*", 2)
+        new_con(machine, 3)
+        new_con(machine, 4)
+
+        # Build outer: +(2, mult)
+        add_addr = new_str(machine, "+", 2)
+        new_con(machine, 2)  # arg1: constant 2
+        note_struct_args(machine, mult_addr)  # arg2: REF(mult)
+
+        result = eval_arithmetic(add_addr, machine)
+
+        assert result == 14
+
+    def test_deeply_nested(self):
+        """Evaluate ((1 + 2) * (3 + 4)) → 21."""
+        machine = Machine()
+
+        # Build inner1: +(1, 2)
+        inner1_addr = new_str(machine, "+", 2)
+        new_con(machine, 1)
+        new_con(machine, 2)
+
+        # Build inner2: +(3, 4)
+        inner2_addr = new_str(machine, "+", 2)
+        new_con(machine, 3)
+        new_con(machine, 4)
+
+        # Build outer: *(inner1, inner2)
+        outer_addr = new_str(machine, "*", 2)
+        note_struct_args(machine, inner1_addr)  # arg1: REF(inner1)
+        note_struct_args(machine, inner2_addr)  # arg2: REF(inner2)
+
+        result = eval_arithmetic(outer_addr, machine)
+
+        assert result == 21
+
+
+class TestArithmeticErrors:
+    """Test arithmetic error handling."""
+
+    def test_unbound_variable_raises_instantiation_error(self):
+        """Unbound variable in expression raises InstantiationError."""
+        machine = Machine()
+
+        unbound_addr = new_ref(machine)
+
+        with pytest.raises(InstantiationError):
+            eval_arithmetic(unbound_addr, machine)
+
+    def test_unbound_in_binary_op_raises_instantiation_error(self):
+        """Unbound variable in binary operation raises InstantiationError."""
+        machine = Machine()
+
+        unbound_addr = new_ref(machine)
+
+        # Build: +(2, X) where X is unbound
+        struct_addr = new_str(machine, "+", 2)
+        new_con(machine, 2)
+        note_struct_args(machine, unbound_addr)  # REF to unbound
+
+        with pytest.raises(InstantiationError):
+            eval_arithmetic(struct_addr, machine)
+
+    def test_division_by_zero_raises_evaluation_error(self):
+        """Division by zero raises EvaluationError."""
+        machine = Machine()
+
+        struct_addr = build_const_binary_op(machine, "/", 5, 0)
+
+        with pytest.raises(EvaluationError) as exc_info:
+            eval_arithmetic(struct_addr, machine)
+
+        assert exc_info.value.kwargs["error"] == "zero_divisor"
+
+    def test_integer_division_by_zero_raises_evaluation_error(self):
+        """Integer division by zero raises EvaluationError."""
+        machine = Machine()
+
+        struct_addr = build_const_binary_op(machine, "//", 5, 0)
+
+        with pytest.raises(EvaluationError) as exc_info:
+            eval_arithmetic(struct_addr, machine)
+
+        assert exc_info.value.kwargs["error"] == "zero_divisor"
+
+    def test_modulo_by_zero_raises_evaluation_error(self):
+        """Modulo by zero raises EvaluationError."""
+        machine = Machine()
+
+        struct_addr = build_const_binary_op(machine, "mod", 5, 0)
+
+        with pytest.raises(EvaluationError) as exc_info:
+            eval_arithmetic(struct_addr, machine)
+
+        assert exc_info.value.kwargs["error"] == "zero_divisor"
+
+    def test_non_numeric_constant_raises_type_error(self):
+        """Non-numeric constant raises TypeError."""
+        machine = Machine()
+
+        atom_addr = new_con(machine, "foo")
+
+        with pytest.raises(TypeError) as exc_info:
+            eval_arithmetic(atom_addr, machine)
+
+        assert exc_info.value.kwargs["expected"] == "number"
+
+    def test_boolean_constant_raises_type_error(self):
+        """Boolean constant raises TypeError."""
+        machine = Machine()
+
+        bool_addr = new_con(machine, True)
+
+        with pytest.raises(TypeError) as exc_info:
+            eval_arithmetic(bool_addr, machine)
+
+        assert exc_info.value.kwargs["expected"] == "number"
+
+    def test_unknown_operator_raises_type_error(self):
+        """Unknown operator raises TypeError."""
+        machine = Machine()
+
+        struct_addr = build_const_binary_op(machine, "unknown_op", 1, 2)
+
+        with pytest.raises(TypeError) as exc_info:
+            eval_arithmetic(struct_addr, machine)
+
+        assert exc_info.value.kwargs["expected"] == "evaluable"

--- a/prolog/wam/arithmetic.py
+++ b/prolog/wam/arithmetic.py
@@ -1,0 +1,160 @@
+"""WAM arithmetic evaluation engine.
+
+Implements recursive arithmetic evaluation operating directly on WAM heap cells.
+Supports standard Prolog arithmetic operators with proper error handling.
+
+Operators:
+- Binary: +, -, *, //, mod, /
+- Unary: -, +
+
+Error Conditions:
+- instantiation_error: Unbound variable in expression
+- type_error: Non-numeric argument
+- evaluation_error(zero_divisor): Division by zero
+"""
+
+from __future__ import annotations
+
+from prolog.ast.terms import Atom, Int
+from prolog.wam.errors import EvaluationError, InstantiationError, TypeError
+from prolog.wam.heap import TAG_CON, TAG_REF, TAG_STR
+from prolog.wam.unify import deref
+
+__all__ = [
+    "eval_arithmetic",
+]
+
+
+def eval_arithmetic(addr: int, machine) -> int | float:
+    """Evaluate arithmetic expression at heap address.
+
+    Args:
+        addr: Heap address of expression root
+        machine: Machine instance with heap
+
+    Returns:
+        Numeric result (int or float)
+
+    Raises:
+        InstantiationError: If expression contains unbound variables
+        TypeError: If expression contains non-numeric terms
+        EvaluationError: If division by zero or other evaluation errors
+
+    Examples:
+        # Simple constant
+        heap[0] = (TAG_CON, 42)
+        eval_arithmetic(0, machine) → 42
+
+        # Binary operation: 2 + 3
+        heap[0] = (TAG_STR, 1)
+        heap[1] = (TAG_CON, ("+", 2))
+        heap[2] = (TAG_CON, 2)
+        heap[3] = (TAG_CON, 3)
+        eval_arithmetic(0, machine) → 5
+
+        # Unary minus: -(5)
+        heap[0] = (TAG_STR, 1)
+        heap[1] = (TAG_CON, ("-", 1))
+        heap[2] = (TAG_CON, 5)
+        eval_arithmetic(0, machine) → -5
+
+        # Unbound variable
+        heap[0] = (TAG_REF, 0)
+        eval_arithmetic(0, machine) → raises InstantiationError
+    """
+    # Dereference to get actual term
+    addr = deref(machine, addr)
+    cell = machine.heap[addr]
+    tag = cell[0]
+
+    # Constant: must be numeric
+    if tag == TAG_CON:
+        value = cell[1]
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value
+        else:
+            # Non-numeric constant
+            if isinstance(value, str):
+                culprit = Atom(value)
+            elif isinstance(value, bool):
+                culprit = Atom(str(value).lower())
+            else:
+                culprit = Int(0)  # Placeholder
+            raise TypeError("number", culprit)
+
+    # Unbound variable
+    elif tag == TAG_REF and cell[1] == addr:
+        raise InstantiationError("arithmetic expression")
+
+    # Structure: operator application
+    elif tag == TAG_STR:
+        functor_addr = cell[1]
+        functor_cell = machine.heap[functor_addr]
+
+        if functor_cell[0] != TAG_CON:
+
+            raise TypeError("number", Atom("?"))
+
+        functor_data = functor_cell[1]
+        if not isinstance(functor_data, tuple) or len(functor_data) != 2:
+
+            raise TypeError("number", Atom("?"))
+
+        name, arity = functor_data
+
+        # Binary operators
+        if arity == 2:
+            left_addr = functor_addr + 1
+            right_addr = functor_addr + 2
+
+            # Recursively evaluate operands
+            left = eval_arithmetic(left_addr, machine)
+            right = eval_arithmetic(right_addr, machine)
+
+            if name == "+":
+                return left + right
+            elif name == "-":
+                return left - right
+            elif name == "*":
+                return left * right
+            elif name == "/":
+                # Float division
+                if right == 0:
+                    raise EvaluationError("zero_divisor")
+                return left / right
+            elif name == "//":
+                # Integer division (floor division toward negative infinity)
+                if right == 0:
+                    raise EvaluationError("zero_divisor")
+                return int(left // right)
+            elif name == "mod":
+                # Modulo operation
+                if right == 0:
+                    raise EvaluationError("zero_divisor")
+                return int(left % right)
+            else:
+                # Unknown binary operator
+                raise TypeError("evaluable", Atom(f"{name}/{arity}"))
+
+        # Unary operators
+        elif arity == 1:
+            arg_addr = functor_addr + 1
+            arg = eval_arithmetic(arg_addr, machine)
+
+            if name == "-":
+                return -arg
+            elif name == "+":
+                return +arg
+            else:
+                # Unknown unary operator
+                raise TypeError("evaluable", Atom(f"{name}/{arity}"))
+
+        else:
+            # Invalid arity for arithmetic
+
+            raise TypeError("evaluable", Atom(f"{name}/{arity}"))
+
+    else:
+        # Unknown tag type
+
+        raise TypeError("number", Atom("?"))


### PR DESCRIPTION
Implements recursive arithmetic evaluation operating directly on WAM heap cells without bridging to tree-walker.

## Implementation

Module: [prolog/wam/arithmetic.py](prolog/wam/arithmetic.py)
- `eval_arithmetic(addr: int, machine) -> int | float`: Evaluates arithmetic expression at heap address
- Recursive evaluation of heap structures with proper dereferencing
- Direct handling of TAG_CON (constants), TAG_REF (variables), TAG_STR (structures)

## Operators Supported

Binary: `+`, `-`, `*`, `/`, `//`, `mod`
Unary: `-`, `+`

## Error Handling

- `InstantiationError`: Unbound variable in expression
- `TypeError`: Non-numeric argument or unknown operator
- `EvaluationError(zero_divisor)`: Division by zero

## Test Coverage

Test suite: [prolog/tests/unit/test_wam_arithmetic.py](prolog/tests/unit/test_wam_arithmetic.py)
- 26 new tests covering constants, binary/unary operators, nested expressions, error conditions
- Test helpers for building heap structures with proper REF cells
- All 736 WAM tests passing (710 existing + 26 new)

Resolves #384