### PR TITLE
Fix member solution display for unbound bindings

### DIFF
--- a/prolog/tests/unit/test_pretty.py
+++ b/prolog/tests/unit/test_pretty.py
@@ -335,11 +335,20 @@ class TestPrettySolution:
         """Pretty print solution with unbound variable."""
         # Unbound variables remain as variables
         bindings = {"X": Var(0, "X")}
-        assert pretty_solution(bindings) == "X = X"
+        assert pretty_solution(bindings) == "true"
 
         # Variable bound to another variable
         bindings = {"X": Var(1, "Y")}
         assert pretty_solution(bindings) == "X = Y"
+
+    def test_pretty_solution_variable_alias_chain(self):
+        """Pretty print solution with multiple variables sharing the same Var."""
+        bindings = {
+            "X": Var(0, "X"),
+            "Y": Var(0, "X"),
+            "Z": Var(0, "X"),
+        }
+        assert pretty_solution(bindings) == "X = Y, Y = Z"
 
     def test_pretty_solution_with_quoted_values(self):
         """Pretty print solution with values that need quoting."""


### PR DESCRIPTION
## Summary
- skip trivial self-bindings when pretty-printing solutions and emit alias chains
- reuse the shared pretty_solution helper for REPL interactive and CLI output
- extend pretty/REPL unit tests to cover unbound and alias formatting

References: #411 

## Testing
- python -m pytest prolog/tests/unit/test_pretty.py prolog/tests/unit/test_repl.py
- git push origin membership-bug (runs fast unit tests)